### PR TITLE
Support legacy SM2 options

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -340,4 +340,16 @@ void app_providers_cleanup(void);
 EVP_PKEY *app_keygen(EVP_PKEY_CTX *ctx, const char *alg, int bits, int verbose);
 EVP_PKEY *app_paramgen(EVP_PKEY_CTX *ctx, const char *alg);
 
+/* for SM2 compatibility usage */
+#define DISTID           "distid:"
+#define DISTID_LEN       (sizeof("distid:") - 1)
+#define HEXDISTID        "hexdistid:"
+#define HEXDISTID_LEN    (sizeof("hexdistid:") - 1)
+#define SM2ID            "sm2_id:"
+#define SM2ID_LEN        (sizeof("sm2_id:") - 1)
+#define SM2HEXID         "sm2_hex_id:"
+#define SM2HEXID_LEN     (sizeof("sm2_hex_id:") - 1)
+
+int build_vfyopt_compat_string(int option, char **ret, const char *value);
+int build_sigopt_compat_string(char **ret, const char *value);
 #endif

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -64,6 +64,8 @@ B<openssl> B<ca>
 [B<-multivalue-rdn>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
+[B<-sm2-id> I<string>]
+[B<-sm2-hex-id> I<hex-string>]
 [I<certreq>...]
 
 =head1 DESCRIPTION
@@ -336,6 +338,20 @@ This option has been deprecated and has no effect.
 {- $OpenSSL::safe::opt_engine_item -}
 
 {- $OpenSSL::safe::opt_provider_item -}
+
+=item B<-sm2-id>
+
+Specify the ID string to use when verifying an SM2 certificate. The ID string is
+required by the SM2 signature algorithm for signing and verification.
+
+This is a compatible option for older Tongsuo/BabaSSL versions.
+
+=item B<-sm2-hex-id>
+
+Specify a binary ID string to use when signing or verifying using an SM2
+certificate. The argument for this option is string of hexadecimal digits.
+
+This is a compatible option for older Tongsuo/BabaSSL versions.
 
 =back
 

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -55,6 +55,8 @@ B<openssl> B<req>
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
+[B<-sm2-id> I<string>]
+[B<-sm2-hex-id> I<hex-string>]
 
 =head1 DESCRIPTION
 
@@ -398,6 +400,20 @@ for key generation operations.
 {- $OpenSSL::safe::opt_engine_item -}
 
 {- $OpenSSL::safe::opt_provider_item -}
+
+=item B<-sm2-id>
+
+Specify the ID string to use when verifying an SM2 certificate. The ID string is
+required by the SM2 signature algorithm for signing and verification.
+
+This is a compatible option for older Tongsuo/BabaSSL versions.
+
+=item B<-sm2-hex-id>
+
+Specify a binary ID string to use when signing or verifying using an SM2
+certificate. The argument for this option is string of hexadecimal digits.
+
+This is a compatible option for older Tongsuo/BabaSSL versions.
 
 =back
 

--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -20,6 +20,8 @@ B<openssl> B<verify>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_v_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
+[B<-sm2-id> I<string>]
+[B<-sm2-hex-id> I<hex-string>]
 [B<-->]
 [I<certificate> ...]
 
@@ -101,6 +103,20 @@ with a B<->.
 One or more target certificates to verify, one per file. If no certificates are
 given, this command will attempt to read a single certificate from standard
 input.
+
+=item B<-sm2-id>
+
+Specify the ID string to use when verifying an SM2 certificate. The ID string is
+required by the SM2 signature algorithm for signing and verification.
+
+This is a compatible option for older Tongsuo/BabaSSL versions.
+
+=item B<-sm2-hex-id>
+
+Specify a binary ID string to use when signing or verifying using an SM2
+certificate. The argument for this option is string of hexadecimal digits.
+
+This is a compatible option for older Tongsuo/BabaSSL versions.
 
 =back
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -78,6 +78,8 @@ B<openssl> B<x509>
 [B<-addreject> I<arg>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
+[B<-sm2-id> I<string>]
+[B<-sm2-hex-id> I<hex-string>]
 
 =head1 DESCRIPTION
 
@@ -204,6 +206,20 @@ Do not output a certificate (except for printing as requested by below options).
 =item B<-noout>
 
 This option prevents output except for printing as requested by below options.
+
+=item B<-sm2-id>
+
+Specify the ID string to use when verifying an SM2 certificate. The ID string is
+required by the SM2 signature algorithm for signing and verification.
+
+This is a compatible option for older Tongsuo/BabaSSL versions.
+
+=item B<-sm2-hex-id>
+
+Specify a binary ID string to use when signing or verifying using an SM2
+certificate. The argument for this option is string of hexadecimal digits.
+
+This is a compatible option for older Tongsuo/BabaSSL versions.
 
 =back
 

--- a/test/recipes/20-test_pkeyutl.t
+++ b/test/recipes/20-test_pkeyutl.t
@@ -16,12 +16,12 @@ use OpenSSL::Test::Utils;
 
 setup("test_pkeyutl");
 
-plan tests => 12;
+plan tests => 14;
 
 # For the tests below we use the cert itself as the TBS file
 
 SKIP: {
-    skip "Skipping tests that require EC, SM2 or SM3", 2
+    skip "Skipping tests that require EC, SM2 or SM3", 4
         if disabled("ec") || disabled("sm2") || disabled("sm3");
 
     # SM2
@@ -38,6 +38,21 @@ SKIP: {
                       '-sigfile', 'sm2.sig', '-rawin',
                       '-digest', 'sm3', '-pkeyopt', 'distid:someid']))),
                       "Verify an SM2 signature against a piece of data");
+
+    # SM2 compatible options
+    ok_nofips(run(app(([ 'openssl', 'pkeyutl', '-sign',
+                      '-in', srctop_file('test', 'certs', 'sm2.pem'),
+                      '-inkey', srctop_file('test', 'certs', 'sm2.key'),
+                      '-out', 'sm2.sig', '-rawin',
+                      '-digest', 'sm3', '-pkeyopt', 'sm2_id:someid']))),
+                      "Sign a piece of data using SM2 (compat)");
+    ok_nofips(run(app(([ 'openssl', 'pkeyutl',
+                      '-verify', '-certin',
+                      '-in', srctop_file('test', 'certs', 'sm2.pem'),
+                      '-inkey', srctop_file('test', 'certs', 'sm2.pem'),
+                      '-sigfile', 'sm2.sig', '-rawin',
+                      '-digest', 'sm3', '-pkeyopt', 'sm2_id:someid']))),
+                      "Verify an SM2 signature against a piece of data (compat)");
 }
 
 SKIP: {

--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -29,7 +29,7 @@ sub verify {
     run(app([@args]));
 }
 
-plan tests => 160;
+plan tests => 162;
 
 # Canonical success
 ok(verify("ee-cert", "sslserver", ["root-cert"], ["ca-cert"]),
@@ -445,12 +445,16 @@ SKIP: {
 }
 
 SKIP: {
-    skip "SM2 is not supported by this OpenSSL build", 2 if disabled("sm2");
+    skip "SM2 is not supported by this OpenSSL build", 4 if disabled("sm2");
 
    ok_nofips(verify("sm2", "", ["sm2-ca-cert"], [], "-vfyopt", "distid:1234567812345678"),
        "SM2 ID test");
    ok_nofips(verify("sm2", "", ["sm2-ca-cert"], [], "-vfyopt", "hexdistid:31323334353637383132333435363738"),
        "SM2 hex ID test");
+   ok_nofips(verify("sm2", "", ["sm2-ca-cert"], [], "-sm2-id", "1234567812345678"),
+       "SM2 ID test (compat)");
+   ok_nofips(verify("sm2", "", ["sm2-ca-cert"], [], "-sm2-hex-id", "31323334353637383132333435363738"),
+       "SM2 hex ID test (compat)");
 }
 
 # Mixed content tests


### PR DESCRIPTION
<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

OpenSSL 3.0对于指定SM2 ID的方式修改为了统一的DISTID，并在各命令的-sigopts和-vfyopts中设置。这和BabaSSL的方式有区别，因此在铜锁中需要对BabaSSL的方式进行兼容

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [x] 增加或更新了必要的文档（包括readthedocs上）
- [x] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
