### PR TITLE
支持5个老旧的SM2相关函数

### DIFF
--- a/doc/man3/EVP_PKEY_is_a.pod
+++ b/doc/man3/EVP_PKEY_is_a.pod
@@ -3,7 +3,8 @@
 =head1 NAME
 
 EVP_PKEY_is_a, EVP_PKEY_can_sign, EVP_PKEY_type_names_do_all,
-EVP_PKEY_get0_type_name, EVP_PKEY_get0_description, EVP_PKEY_get0_provider
+EVP_PKEY_get0_type_name, EVP_PKEY_get0_description, EVP_PKEY_get0_provider,
+EVP_PKEY_is_sm2
 - key type and capabilities functions
 
 =head1 SYNOPSIS
@@ -11,6 +12,7 @@ EVP_PKEY_get0_type_name, EVP_PKEY_get0_description, EVP_PKEY_get0_provider
  #include <openssl/evp.h>
 
  int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
+ int EVP_PKEY_is_sm2(const EVP_PKEY *pkey);
  int EVP_PKEY_can_sign(const EVP_PKEY *pkey);
  int EVP_PKEY_type_names_do_all(const EVP_PKEY *pkey,
                                 void (*fn)(const char *name, void *data),
@@ -22,6 +24,9 @@ EVP_PKEY_get0_type_name, EVP_PKEY_get0_description, EVP_PKEY_get0_provider
 =head1 DESCRIPTION
 
 EVP_PKEY_is_a() checks if the key type of I<pkey> is I<name>.
+
+EVP_PKEY_is_sm2() checks if the key type of I<pkey> is SM2. This function is
+only used for compatibility reasons.
 
 EVP_PKEY_can_sign() checks if the functionality for the key type of
 I<pkey> supports signing.  No other check is done, such as whether
@@ -50,6 +55,9 @@ L<EVP_KEYMGMT(3)>.
 =head1 RETURN VALUES
 
 EVP_PKEY_is_a() returns 1 if I<pkey> has the key type I<name>,
+otherwise 0.
+
+EVP_PKEY_is_sm2() returns 1 if I<pkey> has the key type SM2,
 otherwise 0.
 
 EVP_PKEY_can_sign() returns 1 if the I<pkey> key type functionality
@@ -99,7 +107,8 @@ this as an crude example:
 
 =head1 HISTORY
 
-The functions described here were added in OpenSSL 3.0.
+EVP_PKEY_is_sm2() was added in BabaSSL 8.2.0, while other functions described
+here were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -2168,6 +2168,11 @@ OSSL_LIB_CTX *EVP_PKEY_CTX_get0_libctx(EVP_PKEY_CTX *ctx);
 const char *EVP_PKEY_CTX_get0_propq(const EVP_PKEY_CTX *ctx);
 const OSSL_PROVIDER *EVP_PKEY_CTX_get0_provider(const EVP_PKEY_CTX *ctx);
 
+/* for compattibility usage */
+# ifndef OPENSSL_NO_SM2
+#  define EVP_PKEY_is_sm2(pkey) EVP_PKEY_is_a(pkey, "SM2")
+# endif
+
 # ifdef  __cplusplus
 }
 # endif

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -577,6 +577,15 @@ void X509_set0_distinguishing_id(X509 *x, ASN1_OCTET_STRING *d_id);
 ASN1_OCTET_STRING *X509_get0_distinguishing_id(X509 *x);
 void X509_REQ_set0_distinguishing_id(X509_REQ *x, ASN1_OCTET_STRING *d_id);
 ASN1_OCTET_STRING *X509_REQ_get0_distinguishing_id(X509_REQ *x);
+
+/* for compattibility usage */
+# ifndef OPENSSL_NO_SM2
+#  define X509_set0_sm2_id X509_set0_distinguishing_id
+#  define X509_get0_sm2_id X509_get0_distinguishing_id
+#  define X509_REQ_set0_sm2_id X509_REQ_set0_distinguishing_id
+#  define X509_REQ_get0_sm2_id X509_REQ_get0_distinguishing_id
+# endif
+
 int X509_alias_set1(X509 *x, const unsigned char *name, int len);
 int X509_keyid_set1(X509 *x, const unsigned char *id, int len);
 unsigned char *X509_alias_get0(X509 *x, int *len);

--- a/util/other.syms
+++ b/util/other.syms
@@ -695,3 +695,4 @@ SSL_CTX_certs_clear                     define
 OPENSSL_CHECK_TLSEXT_STATUS             define
 SSL_set_SESSION_CTX                     define
 SSL_debug                               define
+EVP_PKEY_is_sm2                         define


### PR DESCRIPTION
There are five SM2 related legacy APIs existed in old BabaSSL version,
this commit makes them usable in Tongsuo to keep the compatibility, this
commit makes them usable in Tongsuo to keep the compatibility.

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 增加或更新了必要的文档（包括readthedocs上）
- [x] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
