### PR TITLE
Support engine methods in s_server

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -168,6 +168,9 @@ __owur int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path);
 
 # endif
 
+#ifndef OPENSSL_NO_ENGINE
+int engine_meth_cb(const char *elem, int len, void *arg);
+#endif
 ENGINE *setup_engine_methods(const char *id, unsigned int methods, int debug);
 # define setup_engine(e, debug) setup_engine_methods(e, (unsigned int)-1, debug)
 void release_engine(ENGINE *e);
@@ -352,4 +355,12 @@ EVP_PKEY *app_paramgen(EVP_PKEY_CTX *ctx, const char *alg);
 
 int build_vfyopt_compat_string(int option, char **ret, const char *value);
 int build_sigopt_compat_string(char **ret, const char *value);
+
+# if defined(OPENSSL_SYS_WINDOWS)
+#  define strcasecmp _stricmp
+#  define strncasecmp _strnicmp
+# else
+#  include <strings.h>
+# endif
+
 #endif

--- a/apps/lib/engine.c
+++ b/apps/lib/engine.c
@@ -38,6 +38,38 @@ static ENGINE *try_load_engine(const char *engine)
     }
     return e;
 }
+
+int engine_meth_cb(const char *elem, int len, void *arg)
+{
+    unsigned int *pmeth = arg;
+    if (elem == NULL)
+        return 0;
+
+    if (strncasecmp(elem, "rsa", 3) == 0) {
+        *pmeth |= ENGINE_METHOD_RSA;
+    } else if (strncasecmp(elem, "dsa", 3) == 0) {
+        *pmeth |= ENGINE_METHOD_DSA;
+    } else if (strncasecmp(elem, "dh", 2) == 0) {
+        *pmeth |= ENGINE_METHOD_DH;
+    }  else if (strncasecmp(elem, "rand", 4) == 0) {
+        *pmeth |= ENGINE_METHOD_RAND;
+    } else if (strncasecmp(elem, "ciphers", 7) == 0) {
+        *pmeth |= ENGINE_METHOD_CIPHERS;
+    } else if (strncasecmp(elem, "digests", 7) == 0) {
+        *pmeth |= ENGINE_METHOD_DIGESTS;
+    } else if (strncasecmp(elem, "pkey_meths", 10) == 0) {
+        *pmeth |= ENGINE_METHOD_PKEY_METHS;
+    } else if (strncasecmp(elem, "pkey_asn1_meths", 15) == 0) {
+        *pmeth |= ENGINE_METHOD_PKEY_ASN1_METHS;
+    } else if (strncasecmp(elem, "ec", 2) == 0) {
+        *pmeth |= ENGINE_METHOD_EC;
+    } else {
+        BIO_printf(bio_err, "invalid engine method\n");
+        return 0;
+    }
+
+    return 1;
+}
 #endif
 
 ENGINE *setup_engine_methods(const char *id, unsigned int methods, int debug)


### PR DESCRIPTION
基于 https://github.com/BabaSSL/BabaSSL/pull/34
但是openssl 3.0已经支持了setup_engine_methods，所以顺势进行了调整

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 增加或更新了必要的文档（包括readthedocs上）
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
