### PR TITLE
Fix daily CI failures

### DIFF
--- a/test/babasslapitest.c
+++ b/test/babasslapitest.c
@@ -1071,7 +1071,7 @@ end:
 }
 #endif
 
-#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305) && !defined(OPENSSL_NO_EC)
 static int test_babassl_optimize_chacha_choose(void)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
@@ -1564,7 +1564,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_SESSION_REUSED_TYPE
     ADD_TEST(test_babassl_session_reused_type);
 #endif
-#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_EC)
+#if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305) && !defined(OPENSSL_NO_EC)
     ADD_TEST(test_babassl_optimize_chacha_choose);
 #endif
 #if !defined(OPENSSL_NO_STATUS) && !defined(OPENSSL_NO_EC)

--- a/test/ssl-tests/30-tls13-sm.cnf
+++ b/test/ssl-tests/30-tls13-sm.cnf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 22
+num_tests = 21
 
 test-0 = 0-test ciphersuites TLS_SM4_GCM_SM3
 test-1 = 1-test series of ciphersuites includes TLS_SM4_GCM_SM3
@@ -8,22 +8,21 @@ test-2 = 2-test ciphersuites TLS_SM4_CCM_SM3
 test-3 = 3-test series of ciphersuites includes TLS_SM4_CCM_SM3
 test-4 = 4-test sm2-sm3 signature working well in TLS_AES_128_GCM_SHA256
 test-5 = 5-test sm2-sm3 signature working well in TLS_AES_256_GCM_SHA384
-test-6 = 6-test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256
-test-7 = 7-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag
-test-8 = 8-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag
-test-9 = 9-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag
-test-10 = 10-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag
-test-11 = 11-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag
-test-12 = 12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag
-test-13 = 13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag
-test-14 = 14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag
-test-15 = 15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain
-test-16 = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3
-test-17 = 17-test client should fail when enable sm_tls13_strict without SM2 key_share
-test-18 = 18-test client success when enable sm_tls13_strict with SM2 key_share
-test-19 = 19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher
-test-20 = 20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3
-test-21 = 21-test client auth success when both enable sm_tls13_strict
+test-6 = 6-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag
+test-7 = 7-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag
+test-8 = 8-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag
+test-9 = 9-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag
+test-10 = 10-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag
+test-11 = 11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag
+test-12 = 12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag
+test-13 = 13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag
+test-14 = 14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain
+test-15 = 15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3
+test-16 = 16-test client should fail when enable sm_tls13_strict without SM2 key_share
+test-17 = 17-test client success when enable sm_tls13_strict with SM2 key_share
+test-18 = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher
+test-19 = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3
+test-20 = 20-test client auth success when both enable sm_tls13_strict
 # ===========================================================
 
 [0-test ciphersuites TLS_SM4_GCM_SM3]
@@ -73,7 +72,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
 
 [1-test series of ciphersuites includes TLS_SM4_GCM_SM3-client]
 CipherString = DEFAULT
-Ciphersuites = TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_SM4_GCM_SM3
+Ciphersuites = TLS_AES_128_GCM_SHA256:TLS_SM4_GCM_SM3
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
@@ -133,7 +132,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
 
 [3-test series of ciphersuites includes TLS_SM4_CCM_SM3-client]
 CipherString = DEFAULT
-Ciphersuites = TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_SM4_CCM_SM3
+Ciphersuites = TLS_AES_128_GCM_SHA256:TLS_SM4_CCM_SM3
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
@@ -206,44 +205,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[6-test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256]
-ssl_conf = 6-test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256-ssl
+[6-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag]
+ssl_conf = 6-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-ssl
 
-[6-test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256-ssl]
-server = 6-test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256-server
-client = 6-test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256-client
+[6-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-ssl]
+server = 6-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-server
+client = 6-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-client
 
-[6-test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
-CipherString = DEFAULT
-Ciphersuites = TLS_CHACHA20_POLY1305_SHA256
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
-
-[6-test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256-client]
-CipherString = DEFAULT
-Ciphersuites = TLS_CHACHA20_POLY1305_SHA256
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
-VerifyMode = Peer
-
-[test-6]
-ExpectedCipher = TLS_CHACHA20_POLY1305_SHA256
-ExpectedResult = Success
-
-
-# ===========================================================
-
-[7-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag]
-ssl_conf = 7-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-ssl
-
-[7-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-ssl]
-server = 7-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-server
-client = 7-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-client
-
-[7-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-server]
+[6-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -252,7 +221,37 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
 
-[7-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-client]
+[6-test server can not accept TLS_SM4_GCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-client]
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-6]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[7-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag]
+ssl_conf = 7-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-ssl
+
+[7-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-ssl]
+server = 7-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-server
+client = 7-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-client
+
+[7-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = off
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+
+[7-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 MaxProtocol = TLSv1.3
@@ -261,28 +260,29 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-7]
-ExpectedResult = ServerFail
+ExpectedCipher = TLS_SM4_GCM_SM3
+ExpectedResult = Success
 
 
 # ===========================================================
 
-[8-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag]
-ssl_conf = 8-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-ssl
+[8-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag]
+ssl_conf = 8-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-ssl
 
-[8-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-ssl]
-server = 8-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-server
-client = 8-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-client
+[8-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-ssl]
+server = 8-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-server
+client = 8-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-client
 
-[8-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+[8-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = off
+Enable_sm_tls13_strict = on
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[8-test server accept TLS_SM4_GCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-client]
+[8-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 MaxProtocol = TLSv1.3
@@ -291,29 +291,28 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-8]
-ExpectedCipher = TLS_SM4_GCM_SM3
-ExpectedResult = Success
+ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[9-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag]
-ssl_conf = 9-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-ssl
+[9-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag]
+ssl_conf = 9-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-ssl
 
-[9-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-ssl]
-server = 9-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-server
-client = 9-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-client
+[9-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-ssl]
+server = 9-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-server
+client = 9-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-client
 
-[9-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-server]
+[9-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
+Enable_sm_tls13_strict = off
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[9-test server can not accept TLS_SM4_GCM_SM3 with rsa cert when enable sm_tls13_strict tag-client]
+[9-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 MaxProtocol = TLSv1.3
@@ -322,50 +321,20 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-9]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[10-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag]
-ssl_conf = 10-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-ssl
-
-[10-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-ssl]
-server = 10-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-server
-client = 10-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-client
-
-[10-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = off
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
-
-[10-test server can accept TLS_SM4_GCM_SM3 with rsa cert when disable sm_tls13_strict tag-client]
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-10]
 ExpectedCipher = TLS_SM4_GCM_SM3
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[11-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag]
-ssl_conf = 11-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-ssl
+[10-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag]
+ssl_conf = 10-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-ssl
 
-[11-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-ssl]
-server = 11-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-server
-client = 11-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-client
+[10-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-ssl]
+server = 10-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-server
+client = 10-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-client
 
-[11-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-server]
+[10-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_CCM_SM3
@@ -374,7 +343,37 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
 
-[11-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-client]
+[10-test server can not accept TLS_SM4_CCM_SM3 with ecdsa cert when enable sm_tls13_strict tag-client]
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_CCM_SM3
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-10]
+ExpectedResult = ServerFail
+
+
+# ===========================================================
+
+[11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag]
+ssl_conf = 11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-ssl
+
+[11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-ssl]
+server = 11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-server
+client = 11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-client
+
+[11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_CCM_SM3
+Enable_sm_tls13_strict = off
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
+
+[11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_CCM_SM3
 MaxProtocol = TLSv1.3
@@ -383,50 +382,20 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-11]
-ExpectedResult = ServerFail
-
-
-# ===========================================================
-
-[12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag]
-ssl_conf = 12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-ssl
-
-[12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-ssl]
-server = 12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-server
-client = 12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-client
-
-[12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_CCM_SM3
-Enable_sm_tls13_strict = off
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
-
-[12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable sm_tls13_strict tag-client]
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_CCM_SM3
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
-VerifyMode = Peer
-
-[test-12]
 ExpectedCipher = TLS_SM4_CCM_SM3
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag]
-ssl_conf = 13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-ssl
+[12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag]
+ssl_conf = 12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-ssl
 
-[13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-ssl]
-server = 13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-server
-client = 13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-client
+[12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-ssl]
+server = 12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-server
+client = 12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-client
 
-[13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-server]
+[12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_CCM_SM3
@@ -435,7 +404,7 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-client]
+[12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_CCM_SM3
 MaxProtocol = TLSv1.3
@@ -443,20 +412,20 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-13]
+[test-12]
 ExpectedResult = ServerFail
 
 
 # ===========================================================
 
-[14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag]
-ssl_conf = 14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-ssl
+[13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag]
+ssl_conf = 13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-ssl
 
-[14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-ssl]
-server = 14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-server
-client = 14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-client
+[13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-ssl]
+server = 13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-server
+client = 13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-client
 
-[14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-server]
+[13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_CCM_SM3
@@ -465,12 +434,42 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
-[14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-client]
+[13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_CCM_SM3
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-13]
+ExpectedCipher = TLS_SM4_CCM_SM3
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain]
+ssl_conf = 14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-ssl
+
+[14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-ssl]
+server = 14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-server
+client = 14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-client
+
+[14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_CCM_SM3
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
+
+[14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-client]
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_CCM_SM3
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
 [test-14]
@@ -480,44 +479,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain]
-ssl_conf = 15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-ssl
+[15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3]
+ssl_conf = 15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl
 
-[15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-ssl]
-server = 15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-server
-client = 15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-client
+[15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl]
+server = 15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server
+client = 15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client
 
-[15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_CCM_SM3
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
-
-[15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain-client]
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_CCM_SM3
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
-VerifyMode = Peer
-
-[test-15]
-ExpectedCipher = TLS_SM4_CCM_SM3
-ExpectedResult = Success
-
-
-# ===========================================================
-
-[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3]
-ssl_conf = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl
-
-[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl]
-server = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server
-client = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client
-
-[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server]
+[15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -526,7 +495,7 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 
-[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client]
+[15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 MaxProtocol = TLSv1.3
@@ -534,7 +503,7 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
-[test-16]
+[test-15]
 ExpectedCipher = TLS_SM4_GCM_SM3
 ExpectedHRR = Yes
 ExpectedResult = Success
@@ -542,14 +511,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[17-test client should fail when enable sm_tls13_strict without SM2 key_share]
-ssl_conf = 17-test client should fail when enable sm_tls13_strict without SM2 key_share-ssl
+[16-test client should fail when enable sm_tls13_strict without SM2 key_share]
+ssl_conf = 16-test client should fail when enable sm_tls13_strict without SM2 key_share-ssl
 
-[17-test client should fail when enable sm_tls13_strict without SM2 key_share-ssl]
-server = 17-test client should fail when enable sm_tls13_strict without SM2 key_share-server
-client = 17-test client should fail when enable sm_tls13_strict without SM2 key_share-client
+[16-test client should fail when enable sm_tls13_strict without SM2 key_share-ssl]
+server = 16-test client should fail when enable sm_tls13_strict without SM2 key_share-server
+client = 16-test client should fail when enable sm_tls13_strict without SM2 key_share-client
 
-[17-test client should fail when enable sm_tls13_strict without SM2 key_share-server]
+[16-test client should fail when enable sm_tls13_strict without SM2 key_share-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -558,7 +527,39 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 
-[17-test client should fail when enable sm_tls13_strict without SM2 key_share-client]
+[16-test client should fail when enable sm_tls13_strict without SM2 key_share-client]
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
+VerifyMode = Peer
+
+[test-16]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[17-test client success when enable sm_tls13_strict with SM2 key_share]
+ssl_conf = 17-test client success when enable sm_tls13_strict with SM2 key_share-ssl
+
+[17-test client success when enable sm_tls13_strict with SM2 key_share-ssl]
+server = 17-test client success when enable sm_tls13_strict with SM2 key_share-server
+client = 17-test client success when enable sm_tls13_strict with SM2 key_share-client
+
+[17-test client success when enable sm_tls13_strict with SM2 key_share-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = off
+Groups = SM2
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
+
+[17-test client success when enable sm_tls13_strict with SM2 key_share-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 Enable_sm_tls13_strict = on
@@ -568,38 +569,6 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
 [test-17]
-ExpectedResult = ClientFail
-
-
-# ===========================================================
-
-[18-test client success when enable sm_tls13_strict with SM2 key_share]
-ssl_conf = 18-test client success when enable sm_tls13_strict with SM2 key_share-ssl
-
-[18-test client success when enable sm_tls13_strict with SM2 key_share-ssl]
-server = 18-test client success when enable sm_tls13_strict with SM2 key_share-server
-client = 18-test client success when enable sm_tls13_strict with SM2 key_share-client
-
-[18-test client success when enable sm_tls13_strict with SM2 key_share-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = off
-Groups = SM2
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
-
-[18-test client success when enable sm_tls13_strict with SM2 key_share-client]
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
-VerifyMode = Peer
-
-[test-18]
 ExpectedCipher = TLS_SM4_GCM_SM3
 ExpectedHRR = Yes
 ExpectedResult = Success
@@ -607,14 +576,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher]
-ssl_conf = 19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl
+[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher]
+ssl_conf = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl
 
-[19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl]
-server = 19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server
-client = 19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client
+[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl]
+server = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server
+client = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client
 
-[19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server]
+[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -624,7 +593,7 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
 
-[19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client]
+[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 Enable_sm_tls13_strict = on
@@ -633,21 +602,21 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-19]
+[test-18]
 ExpectedClientAlert = BadCertificate
 ExpectedResult = ClientFail
 
 
 # ===========================================================
 
-[20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3]
-ssl_conf = 20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl
+[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3]
+ssl_conf = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl
 
-[20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl]
-server = 20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server
-client = 20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client
+[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl]
+server = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server
+client = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client
 
-[20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server]
+[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -659,7 +628,42 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
 VerifyMode = Require
 
-[20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client]
+[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
+VerifyMode = Peer
+
+[test-19]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[20-test client auth success when both enable sm_tls13_strict]
+ssl_conf = 20-test client auth success when both enable sm_tls13_strict-ssl
+
+[20-test client auth success when both enable sm_tls13_strict-ssl]
+server = 20-test client auth success when both enable sm_tls13_strict-server
+client = 20-test client auth success when both enable sm_tls13_strict-client
+
+[20-test client auth success when both enable sm_tls13_strict-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
+VerifyMode = Require
+
+[20-test client auth success when both enable sm_tls13_strict-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -671,41 +675,6 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
 [test-20]
-ExpectedResult = ClientFail
-
-
-# ===========================================================
-
-[21-test client auth success when both enable sm_tls13_strict]
-ssl_conf = 21-test client auth success when both enable sm_tls13_strict-ssl
-
-[21-test client auth success when both enable sm_tls13_strict-ssl]
-server = 21-test client auth success when both enable sm_tls13_strict-server
-client = 21-test client auth success when both enable sm_tls13_strict-client
-
-[21-test client auth success when both enable sm_tls13_strict-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
-VerifyMode = Require
-
-[21-test client auth success when both enable sm_tls13_strict-client]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
-VerifyMode = Peer
-
-[test-21]
 ExpectedCipher = TLS_SM4_GCM_SM3
 ExpectedHRR = Yes
 ExpectedResult = Success

--- a/test/ssl-tests/30-tls13-sm.cnf.in
+++ b/test/ssl-tests/30-tls13-sm.cnf.in
@@ -49,7 +49,7 @@ our @tests = (
         client => {
             "MinProtocol" => "TLSv1.3",
             "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_SM4_GCM_SM3",
+            "Ciphersuites" => "TLS_AES_128_GCM_SHA256:TLS_SM4_GCM_SM3",
             "VerifyCAFile" => test_pem("sm2-root.crt"),
         },
         test   => {
@@ -91,7 +91,7 @@ our @tests = (
         client => {
             "MinProtocol" => "TLSv1.3",
             "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_SM4_CCM_SM3",
+            "Ciphersuites" => "TLS_AES_128_GCM_SHA256:TLS_SM4_CCM_SM3",
             "VerifyCAFile" => test_pem("sm2-root.crt"),
         },
         test   => {
@@ -139,27 +139,6 @@ our @tests = (
         test   => {
             "ExpectedResult" => "Success",
             "ExpectedCipher" => "TLS_AES_256_GCM_SHA384",
-        },
-    },
-
-    {
-        name => "test sm2-sm3 signature working well in TLS_CHACHA20_POLY1305_SHA256",
-        server => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_CHACHA20_POLY1305_SHA256",
-            "Certificate" => test_pem("sm2-first-crt.pem"),
-            "PrivateKey" => test_pem("sm2-first-key.pem"),
-        },
-        client => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_CHACHA20_POLY1305_SHA256",
-            "VerifyCAFile" => test_pem("sm2-root.crt"),
-        },
-        test   => {
-            "ExpectedResult" => "Success",
-            "ExpectedCipher" => "TLS_CHACHA20_POLY1305_SHA256",
         },
     },
 


### PR DESCRIPTION
在不编译chacha20和poly1305的时候部分测试用例会失败。其中30-tls13-sm用例使用了含有chacha20和poly1305的加密套件进行测试。考虑到SM2签名和chacha20不是强关联，因此也不必须继续保留在chacha20加密套件下对SM2-SM3签名的兼容能力，因此将涉及到chacha20的相关测试用例从30-tls13-sm中删除。

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [x] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
