### PR TITLE
bn_nist: fix strict aliasing problem

### DIFF
--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -249,17 +249,28 @@ const BIGNUM *BN_get0_nist_prime_521(void)
     return &ossl_bignum_nist_p_521;
 }
 
-static void nist_cp_bn_0(BN_ULONG *dst, const BN_ULONG *src, int top, int max)
-{
-    int i;
-
-#ifdef BN_DEBUG
-    (void)ossl_assert(top <= max);
-#endif
-    for (i = 0; i < top; i++)
-        dst[i] = src[i];
-    for (; i < max; i++)
-        dst[i] = 0;
+/*
+ * To avoid more recent compilers (specifically clang-14) from treating this
+ * code as a violation of the strict aliasing conditions and omiting it, this
+ * cannot be declared as a function.  Moreover, the dst parameter cannot be
+ * cached in a local since this no longer references the union and again falls
+ * foul of the strict aliasing criteria.  Refer to #18225 for the initial
+ * diagnostics and llvm/llvm-project#55255 for the later discussions with the
+ * LLVM developers.  The problem boils down to if an array in the union is
+ * converted to a pointer or if it is used directly.
+ *
+ * This function was inlined regardless, so there is no space cost to be
+ * paid for making it a macro.
+ */
+#define nist_cp_bn_0(dst, src_in, top, max) \
+{                                           \
+    int ii;                                 \
+    const BN_ULONG *src = src_in;           \
+                                            \
+    for (ii = 0; ii < top; ii++)            \
+        (dst)[ii] = src[ii];                \
+    for (; ii < max; ii++)                  \
+        (dst)[ii] = 0;                      \
 }
 
 static void nist_cp_bn(BN_ULONG *dst, const BN_ULONG *src, int top)


### PR DESCRIPTION
As of clang-14 the strict aliasing is causing code to magically disappear. By explicitly inlining the code, the aliasing problem evaporates.

cherry-picked from https://github.com/openssl/openssl/pull/18258

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
