### PR TITLE
add force-ntls config option

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1816,9 +1816,6 @@ int s_client_main(int argc, char **argv)
             goto end;
         }
     }
-    if (enable_force_ntls) {
-        SSL_CTX_enable_force_ntls(ctx);
-    }
 #endif
 
     if (chain_file != NULL) {
@@ -1878,6 +1875,9 @@ int s_client_main(int argc, char **argv)
 #ifndef OPENSSL_NO_NTLS
     if (enable_ntls)
         SSL_CTX_enable_ntls(ctx);
+    if (enable_force_ntls) {
+        SSL_CTX_enable_force_ntls(ctx);
+    }
 #endif
 #ifndef OPENSSL_NO_DELEGATED_CREDENTIAL
     if (enable_verify_peer_by_dc)

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -439,7 +439,7 @@ typedef enum OPTION_choice {
     OPT_SSL3, OPT_SSL_CONFIG,
     OPT_TLS1_3, OPT_TLS1_2, OPT_TLS1_1, OPT_TLS1, OPT_DTLS, OPT_DTLS1,
 #ifndef OPENSSL_NO_NTLS
-    OPT_NTLS, OPT_ENABLE_NTLS,
+    OPT_NTLS, OPT_ENABLE_NTLS, OPT_ENABLE_FORCE_NTLS,
 #endif
 #ifndef OPENSSL_NO_SM2
     OPT_ENABLE_SM_TLS13_STRICT,
@@ -649,6 +649,7 @@ const OPTIONS s_client_options[] = {
 #ifndef OPENSSL_NO_NTLS
     {"ntls", OPT_NTLS, '-', "Just use NTLS"},
     {"enable_ntls", OPT_ENABLE_NTLS, '-', "enable ntls"},
+    {"enable_force_ntls", OPT_ENABLE_FORCE_NTLS, '-', "enable force ntls"},
 #endif
 #ifndef OPENSSL_NO_SM2
     {"enable_sm_tls13_strict", OPT_ENABLE_SM_TLS13_STRICT, '-', "enable sm tls13 strict"},
@@ -855,6 +856,7 @@ int s_client_main(int argc, char **argv)
     char *enc_cert_file = NULL, *enc_key_file = NULL;
     char *sign_cert_file = NULL, *sign_key_file = NULL;
     int enable_ntls = 0;
+    int enable_force_ntls = 0;
 #endif
 #ifndef OPENSSL_NO_SM2
     int enable_sm_tls13_strict = 0;
@@ -1325,6 +1327,9 @@ int s_client_main(int argc, char **argv)
             break;
         case OPT_ENABLE_NTLS:
             enable_ntls = 1;
+            break;
+        case OPT_ENABLE_FORCE_NTLS:
+            enable_force_ntls = 1;
             break;
 #endif
 #ifndef OPENSSL_NO_SM2
@@ -1810,6 +1815,9 @@ int s_client_main(int argc, char **argv)
             ERR_print_errors(bio_err);
             goto end;
         }
+    }
+    if (enable_force_ntls) {
+        SSL_CTX_enable_force_ntls(ctx);
     }
 #endif
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -439,7 +439,7 @@ typedef enum OPTION_choice {
     OPT_SSL3, OPT_SSL_CONFIG,
     OPT_TLS1_3, OPT_TLS1_2, OPT_TLS1_1, OPT_TLS1, OPT_DTLS, OPT_DTLS1,
 #ifndef OPENSSL_NO_NTLS
-    OPT_NTLS, OPT_ENABLE_NTLS, OPT_ENABLE_FORCE_NTLS,
+    OPT_NTLS, OPT_ENABLE_NTLS,
 #endif
 #ifndef OPENSSL_NO_SM2
     OPT_ENABLE_SM_TLS13_STRICT,
@@ -649,7 +649,6 @@ const OPTIONS s_client_options[] = {
 #ifndef OPENSSL_NO_NTLS
     {"ntls", OPT_NTLS, '-', "Just use NTLS"},
     {"enable_ntls", OPT_ENABLE_NTLS, '-', "enable ntls"},
-    {"enable_force_ntls", OPT_ENABLE_FORCE_NTLS, '-', "enable force ntls"},
 #endif
 #ifndef OPENSSL_NO_SM2
     {"enable_sm_tls13_strict", OPT_ENABLE_SM_TLS13_STRICT, '-', "enable sm tls13 strict"},
@@ -856,7 +855,6 @@ int s_client_main(int argc, char **argv)
     char *enc_cert_file = NULL, *enc_key_file = NULL;
     char *sign_cert_file = NULL, *sign_key_file = NULL;
     int enable_ntls = 0;
-    int enable_force_ntls = 0;
 #endif
 #ifndef OPENSSL_NO_SM2
     int enable_sm_tls13_strict = 0;
@@ -1327,9 +1325,6 @@ int s_client_main(int argc, char **argv)
             break;
         case OPT_ENABLE_NTLS:
             enable_ntls = 1;
-            break;
-        case OPT_ENABLE_FORCE_NTLS:
-            enable_force_ntls = 1;
             break;
 #endif
 #ifndef OPENSSL_NO_SM2
@@ -1875,9 +1870,6 @@ int s_client_main(int argc, char **argv)
 #ifndef OPENSSL_NO_NTLS
     if (enable_ntls)
         SSL_CTX_enable_ntls(ctx);
-    if (enable_force_ntls) {
-        SSL_CTX_enable_force_ntls(ctx);
-    }
 #endif
 #ifndef OPENSSL_NO_DELEGATED_CREDENTIAL
     if (enable_verify_peer_by_dc)

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -701,7 +701,7 @@ typedef enum OPTION_choice {
     OPT_SSL3, OPT_TLS1_3, OPT_TLS1_2, OPT_TLS1_1, OPT_TLS1, OPT_DTLS, OPT_DTLS1,
 #ifndef OPENSSL_NO_NTLS
     OPT_NTLS, OPT_ENC_CERT, OPT_ENC_KEY, OPT_SIGN_CERT, OPT_SIGN_KEY,
-    OPT_ENABLE_NTLS, OPT_ENC_CERTFORM, OPT_SIGN_CERTFORM,
+    OPT_ENABLE_NTLS, OPT_ENABLE_FORCE_NTLS, OPT_ENC_CERTFORM, OPT_SIGN_CERTFORM,
     OPT_ENC_KEYFORM, OPT_SIGN_KEYFORM,
 #endif
 #ifndef OPENSSL_NO_SM2
@@ -954,6 +954,7 @@ const OPTIONS s_server_options[] = {
 #ifndef OPENSSL_NO_NTLS
     {"ntls", OPT_NTLS, '-', "Just talk NTLS"},
     {"enable_ntls", OPT_ENABLE_NTLS, '-', "enable ntls"},
+    {"enable_force_ntls", OPT_ENABLE_FORCE_NTLS, '-', "enable force ntls"},
 #endif
 #ifndef OPENSSL_NO_SM2
     {"enable_sm_tls13_strict", OPT_ENABLE_SM_TLS13_STRICT, '-', "enable sm tls13 strict"},
@@ -1098,6 +1099,7 @@ int s_server_main(int argc, char *argv[])
     int s_enc_key_format = FORMAT_PEM;
     int s_sign_key_format = FORMAT_PEM;
     int enable_ntls = 0;
+    int enable_force_ntls = 0;
 #endif
 #ifndef OPENSSL_NO_SM2
     int enable_sm_tls13_strict = 0;
@@ -1625,6 +1627,9 @@ int s_server_main(int argc, char *argv[])
         case OPT_ENABLE_NTLS:
             enable_ntls = 1;
             break;
+        case OPT_ENABLE_FORCE_NTLS:
+            enable_force_ntls = 1;
+            break;
 #endif
 #ifndef OPENSSL_NO_SM2
         case OPT_ENABLE_SM_TLS13_STRICT:
@@ -1975,6 +1980,9 @@ skip:
         next_proto.data = next_protos_parse(&next_proto.len, next_proto_neg_in);
         if (next_proto.data == NULL)
             goto end;
+    }
+    if (enable_force_ntls) {
+        SSL_CTX_enable_force_ntls(ctx);
     }
 #endif
     alpn_ctx.data = NULL;

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1981,9 +1981,6 @@ skip:
         if (next_proto.data == NULL)
             goto end;
     }
-    if (enable_force_ntls) {
-        SSL_CTX_enable_force_ntls(ctx);
-    }
 #endif
     alpn_ctx.data = NULL;
     if (alpn_in) {
@@ -2066,6 +2063,9 @@ skip:
 #ifndef OPENSSL_NO_NTLS
     if (enable_ntls)
         SSL_CTX_enable_ntls(ctx);
+    if (enable_force_ntls) {
+        SSL_CTX_enable_force_ntls(ctx);
+    }
 #endif
 
 #ifndef OPENSSL_NO_SM2

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1797,8 +1797,12 @@ __owur int SSL_CTX_use_sign_PrivateKey_file(SSL_CTX *ctx, const char *file,
                                             int type);
 void SSL_CTX_enable_ntls(SSL_CTX *ctx);
 void SSL_CTX_disable_ntls(SSL_CTX *ctx);
+void SSL_CTX_enable_force_ntls(SSL_CTX *ctx);
+void SSL_CTX_disable_force_ntls(SSL_CTX *ctx);
 void SSL_enable_ntls(SSL *s);
 void SSL_disable_ntls(SSL *s);
+void SSL_enable_force_ntls(SSL *s);
+void SSL_disable_force_ntls(SSL *s);
 # endif
 
 # ifndef OPENSSL_NO_SM2

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -766,6 +766,22 @@ static int cmd_Enable_ntls(SSL_CONF_CTX *cctx, const char *value)
     }
     return 1;
 }
+
+static int cmd_Enable_force_ntls(SSL_CONF_CTX *cctx, const char *value)
+{
+    if (strcmp(value, "on") == 0) {
+        if (cctx->ctx)
+            SSL_CTX_enable_force_ntls(cctx->ctx);
+        if (cctx->ssl)
+            SSL_enable_force_ntls(cctx->ssl);
+    } else {
+        if (cctx->ctx)
+            SSL_CTX_disable_force_ntls(cctx->ctx);
+        if (cctx->ssl)
+            SSL_disable_force_ntls(cctx->ssl);
+    }
+    return 1;
+}
 #endif
 
 #ifndef OPENSSL_NO_SM2
@@ -950,6 +966,7 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
     SSL_CONF_CMD_STRING(NumTickets, "num_tickets", SSL_CONF_FLAG_SERVER),
 #ifndef OPENSSL_NO_NTLS
     SSL_CONF_CMD_STRING(Enable_ntls, "enable_ntls", 0),
+    SSL_CONF_CMD_STRING(Enable_force_ntls, "enable_force_ntls", 0),
     SSL_CONF_CMD(EncCertificate, "enc_cert", SSL_CONF_FLAG_CERTIFICATE,
                  SSL_CONF_TYPE_FILE),
     SSL_CONF_CMD(EncPrivateKey, "enc_key", SSL_CONF_FLAG_CERTIFICATE,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -725,6 +725,7 @@ SSL *SSL_new(SSL_CTX *ctx)
     s->pha_enabled = ctx->pha_enabled;
 #ifndef OPENSSL_NO_NTLS
     s->enable_ntls = ctx->enable_ntls;
+    s->enable_force_ntls = ctx->enable_force_ntls;
 #endif
 #ifndef OPENSSL_NO_SM2
     s->enable_sm_tls13_strict = ctx->enable_sm_tls13_strict;
@@ -3321,6 +3322,7 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
 
 #ifndef OPENSSL_NO_NTLS
     ret->enable_ntls = 0;
+    ret->enable_force_ntls = 0;
 #endif
 #ifndef OPENSSL_NO_SM2
     ret->enable_sm_tls13_strict = 0;
@@ -4356,6 +4358,7 @@ SSL_CTX *SSL_CTX_dup(SSL_CTX *ctx)
 #ifndef OPENSSL_NO_NTLS
     /* Tag of NTLS */
     ret->enable_ntls = ctx->enable_ntls;
+    ret->enable_force_ntls = ctx->enable_force_ntls;
 #endif
 #ifndef OPENSSL_NO_SM2
     ret->enable_sm_tls13_strict = ctx->enable_sm_tls13_strict ;
@@ -6527,6 +6530,18 @@ void SSL_CTX_enable_ntls(SSL_CTX *ctx)
 void SSL_CTX_disable_ntls(SSL_CTX *ctx)
 {
     ctx->enable_ntls = 0;
+    ctx->enable_force_ntls = 0;
+}
+
+void SSL_CTX_enable_force_ntls(SSL_CTX *ctx)
+{
+    ctx->enable_ntls = 1;
+    ctx->enable_force_ntls = 1;
+}
+
+void SSL_CTX_disable_force_ntls(SSL_CTX *ctx)
+{
+    ctx->enable_force_ntls = 0;
 }
 
 void SSL_enable_ntls(SSL *s)
@@ -6537,6 +6552,18 @@ void SSL_enable_ntls(SSL *s)
 void SSL_disable_ntls(SSL *s)
 {
     s->enable_ntls = 0;
+    s->enable_force_ntls = 0;
+}
+
+void SSL_enable_force_ntls(SSL *s)
+{
+    s->enable_ntls = 1;
+    s->enable_force_ntls = 1;
+}
+
+void SSL_disable_force_ntls(SSL *s)
+{
+    s->enable_force_ntls = 0;
 }
 #endif
 const EVP_CIPHER *ssl_evp_cipher_fetch(OSSL_LIB_CTX *libctx,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -6530,12 +6530,10 @@ void SSL_CTX_enable_ntls(SSL_CTX *ctx)
 void SSL_CTX_disable_ntls(SSL_CTX *ctx)
 {
     ctx->enable_ntls = 0;
-    ctx->enable_force_ntls = 0;
 }
 
 void SSL_CTX_enable_force_ntls(SSL_CTX *ctx)
 {
-    ctx->enable_ntls = 1;
     ctx->enable_force_ntls = 1;
 }
 
@@ -6552,12 +6550,10 @@ void SSL_enable_ntls(SSL *s)
 void SSL_disable_ntls(SSL *s)
 {
     s->enable_ntls = 0;
-    s->enable_force_ntls = 0;
 }
 
 void SSL_enable_force_ntls(SSL *s)
 {
-    s->enable_ntls = 1;
     s->enable_force_ntls = 1;
 }
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1215,6 +1215,7 @@ struct ssl_ctx_st {
 #ifndef OPENSSL_NO_NTLS
     /* Tag of NTLS */
     int enable_ntls;
+    int enable_force_ntls;
 #endif
 #ifndef OPENSSL_NO_SM2
     /*
@@ -1893,6 +1894,7 @@ struct ssl_st {
 
 # ifndef OPENSSL_NO_NTLS
     int enable_ntls;
+    int enable_force_ntls;
 # endif
 # ifndef OPENSSL_NO_SKIP_SCSV
     int skip_scsv;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -268,9 +268,7 @@ int ossl_statem_connect(SSL *s)
 #ifndef OPENSSL_NO_NTLS
     int ret;
 
-    if (s->enable_force_ntls == 1)
-        return state_machine_ntls(s, 0);
-    else if (s->enable_ntls == 1) {
+    if (s->enable_ntls == 1) {
         ret = SSL_connection_is_ntls(s, 0);
         if (ret == 0)
             return state_machine(s, 0);

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -268,7 +268,9 @@ int ossl_statem_connect(SSL *s)
 #ifndef OPENSSL_NO_NTLS
     int ret;
 
-    if (s->enable_ntls == 1) {
+    if (s->enable_force_ntls == 1)
+        return state_machine_ntls(s, 0);
+    else if (s->enable_ntls == 1) {
         ret = SSL_connection_is_ntls(s, 0);
         if (ret == 0)
             return state_machine(s, 0);
@@ -286,7 +288,9 @@ int ossl_statem_accept(SSL *s)
 #ifndef OPENSSL_NO_NTLS
     int ret;
 
-    if (s->enable_ntls == 1) {
+    if (s->enable_force_ntls == 1)
+        return state_machine_ntls(s, 1);
+    else if (s->enable_ntls == 1) {
         ret = SSL_connection_is_ntls(s, 1);
         if (ret == 0)
             return state_machine(s, 1);

--- a/test/ssl-tests/31-ntls.cnf
+++ b/test/ssl-tests/31-ntls.cnf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 17
+num_tests = 19
 
 test-0 = 0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only
 test-1 = 1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only
@@ -19,6 +19,8 @@ test-13 = 13-test server choose RSA-SM4 with RSA double certs only
 test-14 = 14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs
 test-15 = 15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs
 test-16 = 16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs
+test-17 = 17-test ntls client handshake with server which has set enable_force_ntls
+test-18 = 18-test tls client handshake with server which has set enable_force_ntls
 # ===========================================================
 
 [0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only]
@@ -576,5 +578,68 @@ ExpectedCipher = ECC-SM2-SM4-CBC-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
 Method = NTLS
+
+
+# ===========================================================
+
+[17-test ntls client handshake with server which has set enable_force_ntls]
+ssl_conf = 17-test ntls client handshake with server which has set enable_force_ntls-ssl
+
+[17-test ntls client handshake with server which has set enable_force_ntls-ssl]
+server = 17-test ntls client handshake with server which has set enable_force_ntls-server
+client = 17-test ntls client handshake with server which has set enable_force_ntls-client
+
+[17-test ntls client handshake with server which has set enable_force_ntls-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Enable_force_ntls = on
+Enable_ntls = on
+EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.crt
+EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
+SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
+
+[17-test ntls client handshake with server which has set enable_force_ntls-client]
+CipherString = DEFAULT
+Enable_ntls = on
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
+VerifyMode = Peer
+
+[test-17]
+ExpectedProtocol = NTLS
+ExpectedResult = Success
+Method = NTLS
+
+
+# ===========================================================
+
+[18-test tls client handshake with server which has set enable_force_ntls]
+ssl_conf = 18-test tls client handshake with server which has set enable_force_ntls-ssl
+
+[18-test tls client handshake with server which has set enable_force_ntls-ssl]
+server = 18-test tls client handshake with server which has set enable_force_ntls-server
+client = 18-test tls client handshake with server which has set enable_force_ntls-client
+
+[18-test tls client handshake with server which has set enable_force_ntls-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Enable_force_ntls = on
+Enable_ntls = on
+EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.crt
+EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
+SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
+
+[18-test tls client handshake with server which has set enable_force_ntls-client]
+CipherString = DEFAULT
+Enable_ntls = off
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-18]
+ExpectedResult = ServerFail
+Method = TLS
 
 

--- a/test/ssl-tests/31-ntls.cnf.in
+++ b/test/ssl-tests/31-ntls.cnf.in
@@ -203,46 +203,6 @@ our @tests = (
     },
 
     {
-        name => "test ntls client handshake with server which has set enable_force_ntls",
-        server => {
-            "SignCertificate" => test_pem("sm2", "server_sign.crt"),
-            "SignPrivateKey" => test_pem("sm2", "server_sign.key"),
-            "EncCertificate" => test_pem("sm2", "server_enc.crt"),
-            "EncPrivateKey" => test_pem("sm2", "server_enc.key"),
-            "Enable_ntls" => "on",
-            "Enable_force_ntls" => "on",
-        },
-        client => {
-            "VerifyCAFile" => test_pem("sm2", "chain-ca.crt"),
-            "Enable_ntls" => "on",
-        },
-        test   => {
-            "Method" => "NTLS",
-            "ExpectedResult" => "Success",
-            "ExpectedProtocol" => "NTLS",
-        },
-    },
-
-    {
-        name => "test tls client handshake with server which has set enable_force_ntls",
-        server => {
-            "SignCertificate" => test_pem("sm2", "server_sign.crt"),
-            "SignPrivateKey" => test_pem("sm2", "server_sign.key"),
-            "EncCertificate" => test_pem("sm2", "server_enc.crt"),
-            "EncPrivateKey" => test_pem("sm2", "server_enc.key"),
-            "Enable_ntls" => "on",
-            "Enable_force_ntls" => "on",
-        },
-        client => {
-            "Enable_ntls" => "off",
-        },
-        test   => {
-            "Method" => "TLS",
-            "ExpectedResult" => "ClientFail",
-        },
-    },
-
-    {
         name => "test ntls client doing handshake without setting certs and pkey",
         server => {
             "Enable_ntls" => "on",
@@ -443,6 +403,46 @@ our @tests = (
             "ExpectedResult" => "Success",
             "ExpectedCipher" => "ECC-SM2-SM4-CBC-SM3",
             "ExpectedProtocol" => "NTLS",
+        },
+    },
+
+    {
+        name => "test ntls client handshake with server which has set enable_force_ntls",
+        server => {
+            "SignCertificate" => test_pem("sm2", "server_sign.crt"),
+            "SignPrivateKey" => test_pem("sm2", "server_sign.key"),
+            "EncCertificate" => test_pem("sm2", "server_enc.crt"),
+            "EncPrivateKey" => test_pem("sm2", "server_enc.key"),
+            "Enable_ntls" => "on",
+            "Enable_force_ntls" => "on",
+        },
+        client => {
+            "VerifyCAFile" => test_pem("sm2", "chain-ca.crt"),
+            "Enable_ntls" => "on",
+        },
+        test   => {
+            "Method" => "NTLS",
+            "ExpectedResult" => "Success",
+            "ExpectedProtocol" => "NTLS",
+        },
+    },
+
+    {
+        name => "test tls client handshake with server which has set enable_force_ntls",
+        server => {
+            "SignCertificate" => test_pem("sm2", "server_sign.crt"),
+            "SignPrivateKey" => test_pem("sm2", "server_sign.key"),
+            "EncCertificate" => test_pem("sm2", "server_enc.crt"),
+            "EncPrivateKey" => test_pem("sm2", "server_enc.key"),
+            "Enable_ntls" => "on",
+            "Enable_force_ntls" => "on",
+        },
+        client => {
+            "Enable_ntls" => "off",
+        },
+        test   => {
+            "Method" => "TLS",
+            "ExpectedResult" => "ServerFail",
         },
     },
 );

--- a/test/ssl-tests/31-ntls.cnf.in
+++ b/test/ssl-tests/31-ntls.cnf.in
@@ -203,6 +203,46 @@ our @tests = (
     },
 
     {
+        name => "test ntls client handshake with server which has set enable_force_ntls",
+        server => {
+            "SignCertificate" => test_pem("sm2", "server_sign.crt"),
+            "SignPrivateKey" => test_pem("sm2", "server_sign.key"),
+            "EncCertificate" => test_pem("sm2", "server_enc.crt"),
+            "EncPrivateKey" => test_pem("sm2", "server_enc.key"),
+            "Enable_ntls" => "on",
+            "Enable_force_ntls" => "on",
+        },
+        client => {
+            "VerifyCAFile" => test_pem("sm2", "chain-ca.crt"),
+            "Enable_ntls" => "on",
+        },
+        test   => {
+            "Method" => "NTLS",
+            "ExpectedResult" => "Success",
+            "ExpectedProtocol" => "NTLS",
+        },
+    },
+
+    {
+        name => "test tls client handshake with server which has set enable_force_ntls",
+        server => {
+            "SignCertificate" => test_pem("sm2", "server_sign.crt"),
+            "SignPrivateKey" => test_pem("sm2", "server_sign.key"),
+            "EncCertificate" => test_pem("sm2", "server_enc.crt"),
+            "EncPrivateKey" => test_pem("sm2", "server_enc.key"),
+            "Enable_ntls" => "on",
+            "Enable_force_ntls" => "on",
+        },
+        client => {
+            "Enable_ntls" => "off",
+        },
+        test   => {
+            "Method" => "TLS",
+            "ExpectedResult" => "ClientFail",
+        },
+    },
+
+    {
         name => "test ntls client doing handshake without setting certs and pkey",
         server => {
             "Enable_ntls" => "on",

--- a/test/ssl_ntls_api_test.c
+++ b/test/ssl_ntls_api_test.c
@@ -141,6 +141,18 @@ static int test_ntls_ctx_set_cert_pkey_file_api(int i)
     SSL_CTX_disable_ntls(ctx);
     if (!TEST_true(ctx->enable_ntls == 0))
         goto err;
+    if (!TEST_true(ctx->enable_force_ntls == 0))
+        goto err;
+
+
+    SSL_CTX_enable_force_ntls(ctx);
+    if (!TEST_true(ctx->enable_ntls == 1))
+        goto err;
+    if (!TEST_true(ctx->enable_force_ntls == 1))
+        goto err;
+    SSL_CTX_disable_force_ntls(ctx);
+    if (!TEST_true(ctx->enable_force_ntls == 0))
+        goto err;
 
     if (!TEST_int_eq(SSL_CTX_use_sign_certificate_file(ctx,
                                                        sign_cert_file,
@@ -245,6 +257,17 @@ static int test_ntls_ssl_set_cert_pkey_file_api(int i)
         goto err;
     SSL_disable_ntls(ssl);
     if (!TEST_true(ssl->enable_ntls == 0))
+        goto err;
+    if (!TEST_true(ssl->enable_force_ntls == 0))
+        goto err;
+
+    SSL_enable_force_ntls(ssl);
+    if (!TEST_true(ssl->enable_ntls == 1))
+        goto err;
+    if (!TEST_true(ssl->enable_force_ntls == 1))
+        goto err;
+    SSL_disable_force_ntls(ssl);
+    if (!TEST_true(ssl->enable_force_ntls == 0))
         goto err;
 
     if (!TEST_int_eq(SSL_use_sign_certificate_file(ssl,

--- a/test/ssl_ntls_api_test.c
+++ b/test/ssl_ntls_api_test.c
@@ -141,13 +141,8 @@ static int test_ntls_ctx_set_cert_pkey_file_api(int i)
     SSL_CTX_disable_ntls(ctx);
     if (!TEST_true(ctx->enable_ntls == 0))
         goto err;
-    if (!TEST_true(ctx->enable_force_ntls == 0))
-        goto err;
-
 
     SSL_CTX_enable_force_ntls(ctx);
-    if (!TEST_true(ctx->enable_ntls == 1))
-        goto err;
     if (!TEST_true(ctx->enable_force_ntls == 1))
         goto err;
     SSL_CTX_disable_force_ntls(ctx);
@@ -258,12 +253,8 @@ static int test_ntls_ssl_set_cert_pkey_file_api(int i)
     SSL_disable_ntls(ssl);
     if (!TEST_true(ssl->enable_ntls == 0))
         goto err;
-    if (!TEST_true(ssl->enable_force_ntls == 0))
-        goto err;
 
     SSL_enable_force_ntls(ssl);
-    if (!TEST_true(ssl->enable_ntls == 1))
-        goto err;
     if (!TEST_true(ssl->enable_force_ntls == 1))
         goto err;
     SSL_disable_force_ntls(ssl);

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -625,3 +625,7 @@ SSL_CTX_use_dc_PrivateKey_file          625	3_0_3	EXIST::FUNCTION:DELEGATED_CRED
 DC_print                                626	3_0_3	EXIST::FUNCTION:DELEGATED_CREDENTIAL
 DC_sign                                 627	3_0_3	EXIST::FUNCTION:DELEGATED_CREDENTIAL
 SSL_CTX_dup                             628	3_0_3	EXIST::FUNCTION:
+SSL_CTX_enable_force_ntls               629	3_0_3	EXIST::FUNCTION:NTLS
+SSL_CTX_disable_force_ntls              630	3_0_3	EXIST::FUNCTION:NTLS
+SSL_enable_force_ntls                   631	3_0_3	EXIST::FUNCTION:NTLS
+SSL_disable_force_ntls                  632	3_0_3	EXIST::FUNCTION:NTLS


### PR DESCRIPTION
SSL/SSL CTX 增加enable_force_ntls选项，该选项设置后，server端跳过ntls协议检测，直接使用ntls状态机。
对于当前SSL_connection_is_ntls不适用的场景，可由调用方提前进行协议版本检测，通过该选项直接选择使用NTLS协议。

enable_force_ntls true会设置enable_ntls true
enable_ntls false会设置enable_force_ntls false

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [x] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
