### PR TITLE
Fix CVE-2023-0217

### DIFF
--- a/crypto/ffc/ffc_key_validate.c
+++ b/crypto/ffc/ffc_key_validate.c
@@ -24,6 +24,11 @@ int ossl_ffc_validate_public_key_partial(const FFC_PARAMS *params,
     BN_CTX *ctx = NULL;
 
     *ret = 0;
+    if (params == NULL || pub_key == NULL || params->p == NULL) {
+        *ret = FFC_ERROR_PASSED_NULL_PARAM;
+        return 0;
+    }
+
     ctx = BN_CTX_new_ex(NULL);
     if (ctx == NULL)
         goto err;
@@ -107,6 +112,10 @@ int ossl_ffc_validate_private_key(const BIGNUM *upper, const BIGNUM *priv,
 
     *ret = 0;
 
+    if (priv == NULL || upper == NULL) {
+        *ret = FFC_ERROR_PASSED_NULL_PARAM;
+        goto err;
+    }
     if (BN_cmp(priv, BN_value_one()) < 0) {
         *ret |= FFC_ERROR_PRIVKEY_TOO_SMALL;
         goto err;

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -76,6 +76,7 @@
 # define FFC_ERROR_NOT_SUITABLE_GENERATOR 0x08
 # define FFC_ERROR_PRIVKEY_TOO_SMALL      0x10
 # define FFC_ERROR_PRIVKEY_TOO_LARGE      0x20
+# define FFC_ERROR_PASSED_NULL_PARAM      0x40
 
 /*
  * Finite field cryptography (FFC) domain parameters are used by DH and DSA.

--- a/test/ffc_internal_test.c
+++ b/test/ffc_internal_test.c
@@ -509,6 +509,27 @@ static int ffc_public_validate_test(void)
     if (!TEST_true(ossl_ffc_validate_public_key(params, pub, &res)))
         goto err;
 
+    /* Fail if params is NULL */
+    if (!TEST_false(ossl_ffc_validate_public_key(NULL, pub, &res)))
+        goto err;
+    if (!TEST_int_eq(FFC_ERROR_PASSED_NULL_PARAM, res))
+        goto err;
+    res = -1;
+    /* Fail if pubkey is NULL */
+    if (!TEST_false(ossl_ffc_validate_public_key(params, NULL, &res)))
+        goto err;
+    if (!TEST_int_eq(FFC_ERROR_PASSED_NULL_PARAM, res))
+        goto err;
+    res = -1;
+
+    BN_free(params->p);
+    params->p = NULL;
+    /* Fail if params->p is NULL */
+    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
+        goto err;
+    if (!TEST_int_eq(FFC_ERROR_PASSED_NULL_PARAM, res))
+        goto err;
+
     ret = 1;
 err:
     DH_free(dh);
@@ -564,6 +585,16 @@ static int ffc_private_validate_test(void)
         goto err;
     /* Pass if priv key <= upper - 1 */
     if (!TEST_true(ossl_ffc_validate_private_key(params->q, priv, &res)))
+        goto err;
+
+    if (!TEST_false(ossl_ffc_validate_private_key(NULL, priv, &res)))
+        goto err;
+    if (!TEST_int_eq(FFC_ERROR_PASSED_NULL_PARAM, res))
+        goto err;
+    res = -1;
+    if (!TEST_false(ossl_ffc_validate_private_key(params->q, NULL, &res)))
+        goto err;
+    if (!TEST_int_eq(FFC_ERROR_PASSED_NULL_PARAM, res))
         goto err;
 
     ret = 1;


### PR DESCRIPTION
Fix NULL deference when validating FFC public key.

When attempting to do a BN_Copy of params->p there was no NULL check. Since BN_copy does not check for NULL this is a NULL reference.

As an aside BN_cmp() does do a NULL check, so there are other checks that fail because a NULL is passed. A more general check for NULL params has been added for both FFC public and private key validation instead.

Reviewed-by: Paul Dale <pauli@openssl.org>
Reviewed-by: Matt Caswell <matt@openssl.org>
Reviewed-by: Tomas Mraz <tomas@openssl.org>

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
