### PR TITLE
Fix CVE-2023-0401

### DIFF
--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -84,7 +84,11 @@ static int pkcs7_bio_add_digest(BIO **pbio, X509_ALGOR *alg,
     }
     (void)ERR_pop_to_mark();
 
-    BIO_set_md(btmp, md);
+    if (BIO_set_md(btmp, md) <= 0) {
+        ERR_raise(ERR_LIB_PKCS7, ERR_R_BIO_LIB);
+        EVP_MD_free(fetched);
+        goto err;
+    }
     EVP_MD_free(fetched);
     if (*pbio == NULL)
         *pbio = btmp;
@@ -522,7 +526,11 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
             }
             (void)ERR_pop_to_mark();
 
-            BIO_set_md(btmp, md);
+            if (BIO_set_md(btmp, md) <= 0) {
+                EVP_MD_free(evp_md);
+                ERR_raise(ERR_LIB_PKCS7, ERR_R_BIO_LIB);
+                goto err;
+            }
             EVP_MD_free(evp_md);
             if (out == NULL)
                 out = btmp;


### PR DESCRIPTION
pk7_doit.c: Check return of BIO_set_md() calls

These calls invoke EVP_DigestInit() which can fail for digests with implicit fetches. Subsequent EVP_DigestUpdate() from BIO_write() or EVP_DigestFinal() from BIO_read() will segfault on NULL dereference. This can be triggered by an attacker providing PKCS7 data digested with MD4 for example if the legacy provider is not loaded.

If BIO_set_md() fails the md BIO cannot be used.

Reviewed-by: Paul Dale <pauli@openssl.org>
Reviewed-by: Richard Levitte <levitte@openssl.org>

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
