### PR TITLE
SSL_connection_is_ntls改成使用预读方式判断是否为NTLS，而不是peek

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@
 
  Changes between 8.3.2 and 8.3.3 [xxxx年xx月xx日]
 
+  *) SSL_connection_is_ntls改成使用预读方式判断是否为NTLS
+
   *) 支持SM4-NI优化
 
  Changes between 8.3.1 and 8.3.2 [2022年12月12日]

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3755,12 +3755,13 @@ int SSL_get_error(const SSL *s, int i)
             return SSL_ERROR_WANT_READ;
         }
 #endif
-#ifndef OPENSSL_NO_NTLS
-        if (s->enable_ntls == 1 && SSL_IS_FIRST_HANDSHAKE(s)) {
-            return SSL_ERROR_WANT_READ;
-        }
-#endif
+
         bio = SSL_get_rbio(s);
+#ifndef OPENSSL_NO_NTLS
+        if (s->enable_ntls == 1 && SSL_IS_FIRST_HANDSHAKE(s)
+            && s->preread_len < sizeof(s->preread_buf) && !BIO_eof(bio))
+            return SSL_ERROR_WANT_READ;
+#endif
         if (BIO_should_read(bio))
             return SSL_ERROR_WANT_READ;
         else if (BIO_should_write(bio))

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -790,6 +790,10 @@ typedef struct ssl_ctx_ext_secure_st {
     unsigned char tick_aes_key[TLSEXT_TICK_KEY_LENGTH];
 } SSL_CTX_EXT_SECURE;
 
+# ifndef OPENSSL_NO_NTLS
+#  define PREREAD_HEADER_LENGTH 3
+# endif
+
 struct ssl_ctx_st {
     const SSL_METHOD *method;
     STACK_OF(SSL_CIPHER) *cipher_list;
@@ -1607,6 +1611,9 @@ struct ssl_st {
 
 # ifndef OPENSSL_NO_NTLS
     int enable_ntls;
+
+    uint8_t preread_buf[PREREAD_HEADER_LENGTH];
+    size_t preread_len;
 # endif
 
 #ifndef OPENSSL_NO_SM2


### PR DESCRIPTION
使用直接读取数据的方式，而不是peek，可以更好的适应不同的事件处理方式，
包括ET和LT。同时不用再适配不同类型的bio处理peek数据问题，直接使用
BIO_read()统一处理。

Fix #352

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [x] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
