### PR TITLE
Fix AES OCB encrypt/decrypt for x86 AES-NI

### DIFF
--- a/crypto/aes/asm/aesni-x86.pl
+++ b/crypto/aes/asm/aesni-x86.pl
@@ -2025,7 +2025,7 @@ my ($l_,$block,$i1,$i3,$i5) = ($rounds_,$key_,$rounds,$len,$out);
 	&movdqu		(&QWP(-16*2,$out,$inp),$inout4);
 	&movdqu		(&QWP(-16*1,$out,$inp),$inout5);
 	&cmp		($inp,$len);			# done yet?
-	&jb		(&label("grandloop"));
+	&jbe		(&label("grandloop"));
 
 &set_label("short");
 	&add		($len,16*6);
@@ -2451,7 +2451,7 @@ my ($l_,$block,$i1,$i3,$i5) = ($rounds_,$key_,$rounds,$len,$out);
 	&pxor		($rndkey1,$inout5);
 	&movdqu		(&QWP(-16*1,$out,$inp),$inout5);
 	&cmp		($inp,$len);			# done yet?
-	&jb		(&label("grandloop"));
+	&jbe		(&label("grandloop"));
 
 &set_label("short");
 	&add		($len,16*6);


### PR DESCRIPTION
aesni_ocb_encrypt and aesni_ocb_decrypt operate by having a fast-path that performs operations on 6 16-byte blocks concurrently (the "grandloop") and then proceeds to handle the "short" tail (which can be anywhere from 0 to 5 blocks) that remain.

As part of initialization, the assembly initializes $len to the true length, less 96 bytes and converts it to a pointer so that the $inp can be compared to it. Each iteration of "grandloop" checks to see if there's a full 96-byte chunk to process, and if so, continues. Once this has been exhausted, it falls through to "short", which handles the remaining zero to five blocks.

Unfortunately, the jump at the end of "grandloop" had a fencepost error, doing a `jb` ("jump below") rather than `jbe` (jump below or equal). This should be `jbe`, as $inp is pointing to the *end* of the chunk currently being handled. If $inp == $len, that means that there's a whole 96-byte chunk waiting to be handled. If $inp > $len, then there's 5 or fewer 16-byte blocks left to be handled, and the fall-through is intended.

The net effect of `jb` instead of `jbe` is that the last 16-byte block of the last 96-byte chunk was completely omitted. The contents of `out` in this position were never written to. Additionally, since those bytes were never processed, the authentication tag generated is also incorrect.

The same fencepost error, and identical logic, exists in both aesni_ocb_encrypt and aesni_ocb_decrypt.

This addresses CVE-2022-2097.

Co-authored-by: Alejandro Sedeño <asedeno@google.com>
Co-authored-by: David Benjamin <davidben@google.com>

Reviewed-by: Paul Dale <pauli@openssl.org>
Reviewed-by: Tomas Mraz <tomas@openssl.org>

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
