### PR TITLE
x509: excessive resource use verifying policy constraints

### DIFF
--- a/crypto/x509/pcy_local.h
+++ b/crypto/x509/pcy_local.h
@@ -111,6 +111,11 @@ struct X509_POLICY_LEVEL_st {
 };
 
 struct X509_POLICY_TREE_st {
+    /* The number of nodes in the tree */
+    size_t node_count;
+    /* The maximum number of nodes in the tree */
+    size_t node_maximum;
+
     /* This is the tree 'level' data */
     X509_POLICY_LEVEL *levels;
     int nlevel;
@@ -157,7 +162,8 @@ X509_POLICY_NODE *ossl_policy_tree_find_sk(STACK_OF(X509_POLICY_NODE) *sk,
 X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
                                              X509_POLICY_DATA *data,
                                              X509_POLICY_NODE *parent,
-                                             X509_POLICY_TREE *tree);
+                                             X509_POLICY_TREE *tree,
+                                             int extra_data);
 void ossl_policy_node_free(X509_POLICY_NODE *node);
 int ossl_policy_node_match(const X509_POLICY_LEVEL *lvl,
                            const X509_POLICY_NODE *node, const ASN1_OBJECT *oid);

--- a/crypto/x509/pcy_node.c
+++ b/crypto/x509/pcy_node.c
@@ -59,9 +59,14 @@ X509_POLICY_NODE *ossl_policy_level_find_node(const X509_POLICY_LEVEL *level,
 X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
                                              X509_POLICY_DATA *data,
                                              X509_POLICY_NODE *parent,
-                                             X509_POLICY_TREE *tree)
+                                             X509_POLICY_TREE *tree,
+                                             int extra_data)
 {
     X509_POLICY_NODE *node;
+
+    /* Verify that the tree isn't too large.  This mitigates CVE-2023-0464 */
+    if (tree->node_maximum > 0 && tree->node_count >= tree->node_maximum)
+        return NULL;
 
     node = OPENSSL_zalloc(sizeof(*node));
     if (node == NULL) {
@@ -70,7 +75,7 @@ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
     }
     node->data = data;
     node->parent = parent;
-    if (level) {
+    if (level != NULL) {
         if (OBJ_obj2nid(data->valid_policy) == NID_any_policy) {
             if (level->anyPolicy)
                 goto node_error;
@@ -90,7 +95,7 @@ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
         }
     }
 
-    if (tree) {
+    if (extra_data) {
         if (tree->extra_data == NULL)
             tree->extra_data = sk_X509_POLICY_DATA_new_null();
         if (tree->extra_data == NULL){
@@ -103,6 +108,7 @@ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
         }
     }
 
+    tree->node_count++;
     if (parent)
         parent->nchild++;
 

--- a/crypto/x509/pcy_tree.c
+++ b/crypto/x509/pcy_tree.c
@@ -14,6 +14,17 @@
 
 #include "pcy_local.h"
 
+/*
+ * If the maximum number of nodes in the policy tree isn't defined, set it to
+ * a generous default of 1000 nodes.
+ *
+ * Defining this to be zero means unlimited policy tree growth which opens the
+ * door on CVE-2023-0464.
+ */
+#ifndef OPENSSL_POLICY_TREE_NODES_MAX
+# define OPENSSL_POLICY_TREE_NODES_MAX 1000
+#endif
+
 static void expected_print(BIO *channel,
                            X509_POLICY_LEVEL *lev, X509_POLICY_NODE *node,
                            int indent)
@@ -163,6 +174,9 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
         return X509_PCY_TREE_INTERNAL;
     }
 
+    /* Limit the growth of the tree to mitigate CVE-2023-0464 */
+    tree->node_maximum = OPENSSL_POLICY_TREE_NODES_MAX;
+
     /*
      * http://tools.ietf.org/html/rfc5280#section-6.1.2, figure 3.
      *
@@ -180,7 +194,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
     if ((data = ossl_policy_data_new(NULL,
                                      OBJ_nid2obj(NID_any_policy), 0)) == NULL)
         goto bad_tree;
-    if (ossl_policy_level_add_node(level, data, NULL, tree) == NULL) {
+    if (ossl_policy_level_add_node(level, data, NULL, tree, 1) == NULL) {
         ossl_policy_data_free(data);
         goto bad_tree;
     }
@@ -239,7 +253,8 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
  * Return value: 1 on success, 0 otherwise
  */
 static int tree_link_matching_nodes(X509_POLICY_LEVEL *curr,
-                                    X509_POLICY_DATA *data)
+                                    X509_POLICY_DATA *data,
+                                    X509_POLICY_TREE *tree)
 {
     X509_POLICY_LEVEL *last = curr - 1;
     int i, matched = 0;
@@ -249,13 +264,13 @@ static int tree_link_matching_nodes(X509_POLICY_LEVEL *curr,
         X509_POLICY_NODE *node = sk_X509_POLICY_NODE_value(last->nodes, i);
 
         if (ossl_policy_node_match(last, node, data->valid_policy)) {
-            if (ossl_policy_level_add_node(curr, data, node, NULL) == NULL)
+            if (ossl_policy_level_add_node(curr, data, node, tree, 0) == NULL)
                 return 0;
             matched = 1;
         }
     }
     if (!matched && last->anyPolicy) {
-        if (ossl_policy_level_add_node(curr, data, last->anyPolicy, NULL) == NULL)
+        if (ossl_policy_level_add_node(curr, data, last->anyPolicy, tree, 0) == NULL)
             return 0;
     }
     return 1;
@@ -268,7 +283,8 @@ static int tree_link_matching_nodes(X509_POLICY_LEVEL *curr,
  * Return value: 1 on success, 0 otherwise.
  */
 static int tree_link_nodes(X509_POLICY_LEVEL *curr,
-                           const X509_POLICY_CACHE *cache)
+                           const X509_POLICY_CACHE *cache,
+                           X509_POLICY_TREE *tree)
 {
     int i;
 
@@ -276,7 +292,7 @@ static int tree_link_nodes(X509_POLICY_LEVEL *curr,
         X509_POLICY_DATA *data = sk_X509_POLICY_DATA_value(cache->data, i);
 
         /* Look for matching nodes in previous level */
-        if (!tree_link_matching_nodes(curr, data))
+        if (!tree_link_matching_nodes(curr, data, tree))
             return 0;
     }
     return 1;
@@ -307,7 +323,7 @@ static int tree_add_unmatched(X509_POLICY_LEVEL *curr,
     /* Curr may not have anyPolicy */
     data->qualifier_set = cache->anyPolicy->qualifier_set;
     data->flags |= POLICY_DATA_FLAG_SHARED_QUALIFIERS;
-    if (ossl_policy_level_add_node(curr, data, node, tree) == NULL) {
+    if (ossl_policy_level_add_node(curr, data, node, tree, 1) == NULL) {
         ossl_policy_data_free(data);
         return 0;
     }
@@ -370,7 +386,7 @@ static int tree_link_any(X509_POLICY_LEVEL *curr,
     /* Finally add link to anyPolicy */
     if (last->anyPolicy &&
             ossl_policy_level_add_node(curr, cache->anyPolicy,
-                                       last->anyPolicy, NULL) == NULL)
+                                       last->anyPolicy, tree, 0) == NULL)
         return 0;
     return 1;
 }
@@ -553,7 +569,7 @@ static int tree_calculate_user_set(X509_POLICY_TREE *tree,
             extra->flags = POLICY_DATA_FLAG_SHARED_QUALIFIERS
                 | POLICY_DATA_FLAG_EXTRA_NODE;
             node = ossl_policy_level_add_node(NULL, extra, anyPolicy->parent,
-                                              tree);
+                                              tree, 1);
         }
         if (!tree->user_policies) {
             tree->user_policies = sk_X509_POLICY_NODE_new_null();
@@ -580,7 +596,7 @@ static int tree_evaluate(X509_POLICY_TREE *tree)
 
     for (i = 1; i < tree->nlevel; i++, curr++) {
         cache = ossl_policy_cache_set(curr->cert);
-        if (!tree_link_nodes(curr, cache))
+        if (!tree_link_nodes(curr, cache, tree))
             return X509_PCY_TREE_INTERNAL;
 
         if (!(curr->flags & X509_V_FLAG_INHIBIT_ANY)


### PR DESCRIPTION
A security vulnerability has been identified in all supported versions of OpenSSL related to the verification of X.509 certificate chains that include policy constraints.  Attackers may be able to exploit this vulnerability by creating a malicious certificate chain that triggers exponential use of computational resources, leading to a denial-of-service (DoS) attack on affected systems.

Fixes CVE-2023-0464

Reviewed-by: Tomas Mraz <tomas@openssl.org>
Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
(Merged from https://github.com/openssl/openssl/pull/20568)

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
