### PR TITLE
Ensure that EXFLAG_INVALID_POLICY is checked even in leaf certs

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1656,15 +1656,23 @@ static int check_policy(X509_STORE_CTX *ctx)
         goto memerr;
     /* Invalid or inconsistent extensions */
     if (ret == X509_PCY_TREE_INVALID) {
-        int i;
+        int i, cbcalled = 0;
 
         /* Locate certificates with bad extensions and notify callback. */
-        for (i = 1; i < sk_X509_num(ctx->chain); i++) {
+        for (i = 0; i < sk_X509_num(ctx->chain); i++) {
             X509 *x = sk_X509_value(ctx->chain, i);
 
+            if ((x->ex_flags & EXFLAG_INVALID_POLICY) != 0)
+                cbcalled = 1;
             CB_FAIL_IF((x->ex_flags & EXFLAG_INVALID_POLICY) != 0,
                        ctx, x, i, X509_V_ERR_INVALID_POLICY_EXTENSION);
         }
+        if (!cbcalled) {
+            /* Should not be able to get here */
+            ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+        /* The callback ignored the error so we return success */
         return 1;
     }
     if (ret == X509_PCY_TREE_FAILURE) {


### PR DESCRIPTION
Even though we check the leaf cert to confirm it is valid, we later ignored the invalid flag and did not notice that the leaf cert was bad.

Fixes: CVE-2023-0465

Reviewed-by: Hugo Landau <hlandau@openssl.org>
Reviewed-by: Tomas Mraz <tomas@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/20587)

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
