### PR TITLE
Fix the judgment condition of variable i

### DIFF
--- a/test/punycode_test.c
+++ b/test/punycode_test.c
@@ -154,7 +154,7 @@ static int test_punycode(int n)
     if (!TEST_true(ossl_punycode_decode(tc->encoded, strlen(tc->encoded),
                                         buffer, &bsize)))
         return 0;
-    for (i = 0; i < sizeof(tc->raw); i++)
+    for (i = 0; i < sizeof(tc->raw) / sizeof(int); i++)
         if (tc->raw[i] == 0)
             break;
     if (!TEST_mem_eq(buffer, bsize * sizeof(*buffer),

--- a/test/punycode_test.c
+++ b/test/punycode_test.c
@@ -154,7 +154,7 @@ static int test_punycode(int n)
     if (!TEST_true(ossl_punycode_decode(tc->encoded, strlen(tc->encoded),
                                         buffer, &bsize)))
         return 0;
-    for (i = 0; i < sizeof(tc->raw) / sizeof(int); i++)
+    for (i = 0; i < OSSL_NELEM(tc->raw); i++)
         if (tc->raw[i] == 0)
             break;
     if (!TEST_mem_eq(buffer, bsize * sizeof(*buffer),


### PR DESCRIPTION
在punycode_test.c中，第157行i的判断条件有误，应改为i < sizeof(tc->raw) / sizeof(int)

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
