### PR TITLE
Fix NTLS failed when set min and max version for TLS

### DIFF
--- a/include/openssl/prov_ssl.h
+++ b/include/openssl/prov_ssl.h
@@ -20,6 +20,8 @@ extern "C" {
 # define SSL_MAX_MASTER_KEY_LENGTH 48
 
 # define NTLS1_1_VERSION                 0x0101
+# define NTLS_MAX_VERSION                NTLS1_1_VERSION
+
 # define SSL3_VERSION                    0x0300
 # define TLS1_VERSION                    0x0301
 # define TLS1_1_VERSION                  0x0302

--- a/ssl/statem_ntls/ntls_extensions.c
+++ b/ssl/statem_ntls/ntls_extensions.c
@@ -758,7 +758,7 @@ int tls_construct_extensions_ntls(SSL *s, WPACKET *pkt, unsigned int context,
                              X509 *x, size_t chainidx)
 {
     size_t i;
-    int min_version, max_version = 0, reason;
+    int max_version = NTLS_MAX_VERSION;
     const EXTENSION_DEFINITION *thisexd;
 
     if (!WPACKET_start_sub_packet_u16(pkt)
@@ -773,14 +773,6 @@ int tls_construct_extensions_ntls(SSL *s, WPACKET *pkt, unsigned int context,
                                      WPACKET_FLAGS_ABANDON_ON_ZERO_LENGTH))) {
         SSLfatal_ntls(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
-    }
-
-    if ((context & SSL_EXT_CLIENT_HELLO) != 0) {
-        reason = ssl_get_min_max_version_ntls(s, &min_version, &max_version, NULL);
-        if (reason != 0) {
-            SSLfatal_ntls(s, SSL_AD_INTERNAL_ERROR, reason);
-            return 0;
-        }
     }
 
     /* Add custom extensions first */

--- a/ssl/statem_ntls/ntls_ssl_local.h
+++ b/ssl/statem_ntls/ntls_ssl_local.h
@@ -36,16 +36,11 @@ __owur int ssl_allow_compression_ntls(SSL *s);
 __owur int ssl_version_supported_ntls(const SSL *s, int version,
                                  const SSL_METHOD **meth);
 
-__owur int ssl_set_client_hello_version_ntls(SSL *s);
-__owur int ssl_check_version_downgrade_ntls(SSL *s);
 __owur int ssl_set_version_bound_ntls(int method_version, int version, int *bound);
 __owur int ssl_choose_server_version_ntls(SSL *s, CLIENTHELLO_MSG *hello,
                                      DOWNGRADE *dgrd);
 __owur int ssl_choose_client_version_ntls(SSL *s, int version,
                                      RAW_EXTENSION *extensions);
-__owur int ssl_get_min_max_version_ntls(const SSL *s, int *min_version,
-                                   int *max_version, int *real_max);
-
 __owur int ntls_alert_code(int code);
 __owur int send_certificate_request_ntls(SSL *s);
 

--- a/ssl/statem_ntls/ntls_statem_clnt.c
+++ b/ssl/statem_ntls/ntls_statem_clnt.c
@@ -743,22 +743,13 @@ int tls_construct_client_hello_ntls(SSL *s, WPACKET *pkt)
 {
     unsigned char *p;
     size_t sess_id_len;
-    int i, protverr;
     SSL_SESSION *sess = s->session;
     unsigned char *session_id;
-
-    /* Work out what SSL/TLS version to use */
-    protverr = ssl_set_client_hello_version_ntls(s);
-    if (protverr != 0) {
-        SSLfatal_ntls(s, SSL_AD_INTERNAL_ERROR, protverr);
-        return 0;
-    }
 
     if (sess == NULL
             || !ssl_version_supported_ntls(s, sess->ssl_version, NULL)
             || !SSL_SESSION_is_resumable(sess)) {
-        if (s->hello_retry_request == SSL_HRR_NONE
-                && !ssl_get_new_session(s, 0)) {
+        if (!ssl_get_new_session(s, 0)) {
             /* SSLfatal_ntls() already called */
             return 0;
         }
@@ -766,10 +757,9 @@ int tls_construct_client_hello_ntls(SSL *s, WPACKET *pkt)
     /* else use the pre-loaded session */
 
     p = s->s3.client_random;
-    i = (s->hello_retry_request == SSL_HRR_NONE);
 
-    if (i && ssl_fill_hello_random(s, 0, p, sizeof(s->s3.client_random),
-                                   DOWNGRADE_NONE) <= 0) {
+    if (ssl_fill_hello_random(s, 0, p, sizeof(s->s3.client_random),
+                              DOWNGRADE_NONE) <= 0) {
         SSLfatal_ntls(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }

--- a/ssl/statem_ntls/ntls_statem_srvr.c
+++ b/ssl/statem_ntls/ntls_statem_srvr.c
@@ -749,31 +749,16 @@ static void ssl_check_for_safari(SSL *s, const CLIENTHELLO_MSG *hello)
                                              ext_len);
 }
 
-#define RENEG_OPTIONS_OK(options) \
-    ((options & SSL_OP_NO_RENEGOTIATION) == 0 \
-     && (options & SSL_OP_ALLOW_CLIENT_RENEGOTIATION) != 0)
-
 MSG_PROCESS_RETURN tls_process_client_hello_ntls(SSL *s, PACKET *pkt)
 {
     PACKET session_id, compression, extensions, cookie;
     static const unsigned char null_compression = 0;
     CLIENTHELLO_MSG *clienthello = NULL;
 
-    /* Check if this is actually an unexpected renegotiation ClientHello */
-    if (s->renegotiate == 0 && !SSL_IS_FIRST_HANDSHAKE(s)) {
-        if (!ossl_assert(!SSL_IS_TLS13(s))) {
-            SSLfatal_ntls(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-            goto err;
-        }
-        if (!RENEG_OPTIONS_OK(s->options)
-                || (!s->s3.send_connection_binding
-                    && (s->options
-                        & SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION) == 0)) {
-            ssl3_send_alert(s, SSL3_AL_WARNING, SSL_AD_NO_RENEGOTIATION);
-            return MSG_PROCESS_FINISHED_READING;
-        }
-        s->renegotiate = 1;
-        s->new_session = 1;
+    /* unexpected ClientHello */
+    if (!SSL_IS_FIRST_HANDSHAKE(s)) {
+        ssl3_send_alert(s, SSL3_AL_WARNING, SSL_AD_NO_RENEGOTIATION);
+        return MSG_PROCESS_FINISHED_READING;
     }
 
     clienthello = OPENSSL_zalloc(sizeof(*clienthello));
@@ -964,7 +949,7 @@ MSG_PROCESS_RETURN tls_process_client_hello_ntls(SSL *s, PACKET *pkt)
     return MSG_PROCESS_ERROR;
 }
 
-static int tls_early_post_process_client_hello(SSL *s)
+static int tls_early_post_process_client_hello_ntls(SSL *s)
 {
     unsigned int j;
     int i, al = SSL_AD_INTERNAL_ERROR;
@@ -974,7 +959,6 @@ static int tls_early_post_process_client_hello(SSL *s)
 
     const SSL_CIPHER *c;
     STACK_OF(SSL_CIPHER) *ciphers = NULL;
-    STACK_OF(SSL_CIPHER) *scsvs = NULL;
     CLIENTHELLO_MSG *clienthello = s->clienthello;
     DOWNGRADE dgrd = DOWNGRADE_NONE;
 
@@ -1046,39 +1030,10 @@ static int tls_early_post_process_client_hello(SSL *s)
 
     if (!ssl_cache_cipherlist(s, &clienthello->ciphersuites,
                               clienthello->isv2) ||
-        !bytes_to_cipher_list(s, &clienthello->ciphersuites, &ciphers, &scsvs,
+        !bytes_to_cipher_list(s, &clienthello->ciphersuites, &ciphers, NULL,
                               clienthello->isv2, 1)) {
         /* SSLfatal_ntls() already called */
         goto err;
-    }
-
-    s->s3.send_connection_binding = 0;
-    /* Check what signalling cipher-suite values were received. */
-    if (scsvs != NULL) {
-        for(i = 0; i < sk_SSL_CIPHER_num(scsvs); i++) {
-            c = sk_SSL_CIPHER_value(scsvs, i);
-            if (SSL_CIPHER_get_id(c) == SSL3_CK_SCSV) {
-                if (s->renegotiate) {
-                    /* SCSV is fatal if renegotiating */
-                    SSLfatal_ntls(s, SSL_AD_HANDSHAKE_FAILURE,
-                                  SSL_R_SCSV_RECEIVED_WHEN_RENEGOTIATING);
-                    goto err;
-                }
-                s->s3.send_connection_binding = 1;
-            } else if (SSL_CIPHER_get_id(c) == SSL3_CK_FALLBACK_SCSV &&
-                       !ssl_check_version_downgrade_ntls(s)) {
-                /*
-                 * This SCSV indicates that the client previously tried
-                 * a higher version.  We should fail if the current version
-                 * is an unexpected downgrade, as that indicates that the first
-                 * connection may have been tampered with in order to trigger
-                 * an insecure downgrade.
-                 */
-                SSLfatal_ntls(s, SSL_AD_INAPPROPRIATE_FALLBACK,
-                              SSL_R_INAPPROPRIATE_FALLBACK);
-                goto err;
-            }
-        }
     }
 
     /*
@@ -1270,14 +1225,12 @@ static int tls_early_post_process_client_hello(SSL *s)
     }
 
     sk_SSL_CIPHER_free(ciphers);
-    sk_SSL_CIPHER_free(scsvs);
     OPENSSL_free(clienthello->pre_proc_exts);
     OPENSSL_free(s->clienthello);
     s->clienthello = NULL;
     return 1;
  err:
     sk_SSL_CIPHER_free(ciphers);
-    sk_SSL_CIPHER_free(scsvs);
     OPENSSL_free(clienthello->pre_proc_exts);
     OPENSSL_free(s->clienthello);
     s->clienthello = NULL;
@@ -1418,7 +1371,7 @@ WORK_STATE tls_post_process_client_hello_ntls(SSL *s, WORK_STATE wst)
     const SSL_CIPHER *cipher;
 
     if (wst == WORK_MORE_A) {
-        int rv = tls_early_post_process_client_hello(s);
+        int rv = tls_early_post_process_client_hello_ntls(s);
         if (rv == 0) {
             /* SSLfatal_ntls() was already called */
             goto err;

--- a/test/ssl-tests/31-ntls.cnf
+++ b/test/ssl-tests/31-ntls.cnf
@@ -1,44 +1,47 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 17
+num_tests = 18
 
-test-0 = 0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only
-test-1 = 1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only
-test-2 = 2-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode
-test-3 = 3-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode
-test-4 = 4-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode
-test-5 = 5-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode
-test-6 = 6-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode
-test-7 = 7-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode
-test-8 = 8-test ntls client doing handshake without setting certs and pkey
-test-9 = 9-test server encryption certificate expired
-test-10 = 10-test server sign certificate expired
-test-11 = 11-test server certificates expired
-test-12 = 12-test server choose ECC-SM2-SM4 with SM2 double certs only
-test-13 = 13-test server choose RSA-SM4 with RSA double certs only
-test-14 = 14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs
-test-15 = 15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs
-test-16 = 16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs
+test-0 = 0-test server set min and max TLS version should not affect NTLS
+test-1 = 1-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only
+test-2 = 2-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only
+test-3 = 3-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode
+test-4 = 4-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode
+test-5 = 5-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode
+test-6 = 6-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode
+test-7 = 7-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode
+test-8 = 8-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode
+test-9 = 9-test ntls client doing handshake without setting certs and pkey
+test-10 = 10-test server encryption certificate expired
+test-11 = 11-test server sign certificate expired
+test-12 = 12-test server certificates expired
+test-13 = 13-test server choose ECC-SM2-SM4 with SM2 double certs only
+test-14 = 14-test server choose RSA-SM4 with RSA double certs only
+test-15 = 15-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs
+test-16 = 16-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs
+test-17 = 17-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs
 # ===========================================================
 
-[0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only]
-ssl_conf = 0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-ssl
+[0-test server set min and max TLS version should not affect NTLS]
+ssl_conf = 0-test server set min and max TLS version should not affect NTLS-ssl
 
-[0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-ssl]
-server = 0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-server
-client = 0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-client
+[0-test server set min and max TLS version should not affect NTLS-ssl]
+server = 0-test server set min and max TLS version should not affect NTLS-server
+client = 0-test server set min and max TLS version should not affect NTLS-client
 
-[0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-server]
+[0-test server set min and max TLS version should not affect NTLS-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
 EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.crt
 EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.2
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 
-[0-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-client]
+[0-test server set min and max TLS version should not affect NTLS-client]
 CipherString = ECC-SM2-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
@@ -53,14 +56,14 @@ Method = NTLS
 
 # ===========================================================
 
-[1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only]
-ssl_conf = 1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-ssl
+[1-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only]
+ssl_conf = 1-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-ssl
 
-[1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-ssl]
-server = 1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-server
-client = 1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-client
+[1-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-ssl]
+server = 1-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-server
+client = 1-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-client
 
-[1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-server]
+[1-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
@@ -70,13 +73,45 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 
-[1-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-client]
-CipherString = ECC-SM2-SM4-GCM-SM3
+[1-test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-client]
+CipherString = ECC-SM2-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
 VerifyMode = Peer
 
 [test-1]
+ExpectedCipher = ECC-SM2-SM4-CBC-SM3
+ExpectedProtocol = NTLS
+ExpectedResult = Success
+Method = NTLS
+
+
+# ===========================================================
+
+[2-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only]
+ssl_conf = 2-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-ssl
+
+[2-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-ssl]
+server = 2-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-server
+client = 2-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-client
+
+[2-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Enable_ntls = on
+EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.crt
+EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
+SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
+
+[2-test cipher ECC-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only-client]
+CipherString = ECC-SM2-SM4-GCM-SM3
+Enable_ntls = on
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
+VerifyMode = Peer
+
+[test-2]
 ExpectedCipher = ECC-SM2-SM4-GCM-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -85,14 +120,14 @@ Method = NTLS
 
 # ===========================================================
 
-[2-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode]
-ssl_conf = 2-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-ssl
+[3-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode]
+ssl_conf = 3-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-ssl
 
-[2-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-ssl]
-server = 2-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-server
-client = 2-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-client
+[3-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-ssl]
+server = 3-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-server
+client = 3-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-client
 
-[2-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-server]
+[3-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
@@ -103,7 +138,7 @@ SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
 
-[2-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-client]
+[3-test cipher ECDHE-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode-client]
 CipherString = ECDHE-SM2-SM4-CBC-SM3
 Enable_ntls = on
 EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/client_enc.crt
@@ -113,7 +148,7 @@ SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/client_sign.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
 VerifyMode = Peer
 
-[test-2]
+[test-3]
 ExpectedCipher = ECDHE-SM2-SM4-CBC-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -122,14 +157,14 @@ Method = NTLS
 
 # ===========================================================
 
-[3-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode]
-ssl_conf = 3-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-ssl
+[4-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode]
+ssl_conf = 4-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-ssl
 
-[3-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-ssl]
-server = 3-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-server
-client = 3-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-client
+[4-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-ssl]
+server = 4-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-server
+client = 4-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-client
 
-[3-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-server]
+[4-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
@@ -140,7 +175,7 @@ SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
 
-[3-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-client]
+[4-test cipher ECDHE-SM2-SM4-GCM-SM3 in NTLS_UNIQUE mode-client]
 CipherString = ECDHE-SM2-SM4-GCM-SM3
 Enable_ntls = on
 EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/client_enc.crt
@@ -150,7 +185,7 @@ SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/client_sign.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
 VerifyMode = Peer
 
-[test-3]
+[test-4]
 ExpectedCipher = ECDHE-SM2-SM4-GCM-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -159,14 +194,14 @@ Method = NTLS
 
 # ===========================================================
 
-[4-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode]
-ssl_conf = 4-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-ssl
+[5-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode]
+ssl_conf = 5-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-ssl
 
-[4-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-ssl]
-server = 4-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-server
-client = 4-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-client
+[5-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-ssl]
+server = 5-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-server
+client = 5-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-client
 
-[4-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-server]
+[5-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
@@ -176,13 +211,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.key
 
-[4-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-client]
+[5-test cipher RSA-SM4-CBC-SM3 in NTLS_UNIQUE mode-client]
 CipherString = RSA-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Peer
 
-[test-4]
+[test-5]
 ExpectedCipher = RSA-SM4-CBC-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -191,14 +226,14 @@ Method = NTLS
 
 # ===========================================================
 
-[5-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode]
-ssl_conf = 5-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-ssl
+[6-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode]
+ssl_conf = 6-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-ssl
 
-[5-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-ssl]
-server = 5-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-server
-client = 5-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-client
+[6-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-ssl]
+server = 6-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-server
+client = 6-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-client
 
-[5-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-server]
+[6-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
@@ -208,13 +243,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.key
 
-[5-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-client]
+[6-test cipher RSA-SM4-GCM-SM3 in NTLS_UNIQUE mode-client]
 CipherString = RSA-SM4-GCM-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Peer
 
-[test-5]
+[test-6]
 ExpectedCipher = RSA-SM4-GCM-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -223,14 +258,14 @@ Method = NTLS
 
 # ===========================================================
 
-[6-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode]
-ssl_conf = 6-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-ssl
+[7-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode]
+ssl_conf = 7-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-ssl
 
-[6-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-ssl]
-server = 6-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-server
-client = 6-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-client
+[7-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-ssl]
+server = 7-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-server
+client = 7-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-client
 
-[6-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-server]
+[7-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
@@ -240,13 +275,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.key
 
-[6-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-client]
+[7-test cipher RSA-SM4-CBC-SHA256 in NTLS_UNIQUE mode-client]
 CipherString = RSA-SM4-CBC-SHA256
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Peer
 
-[test-6]
+[test-7]
 ExpectedCipher = RSA-SM4-CBC-SHA256
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -255,14 +290,14 @@ Method = NTLS
 
 # ===========================================================
 
-[7-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode]
-ssl_conf = 7-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-ssl
+[8-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode]
+ssl_conf = 8-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-ssl
 
-[7-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-ssl]
-server = 7-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-server
-client = 7-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-client
+[8-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-ssl]
+server = 8-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-server
+client = 8-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-client
 
-[7-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-server]
+[8-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
@@ -272,13 +307,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.key
 
-[7-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-client]
+[8-test cipher RSA-SM4-GCM-SHA256 in NTLS_UNIQUE mode-client]
 CipherString = RSA-SM4-GCM-SHA256
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Peer
 
-[test-7]
+[test-8]
 ExpectedCipher = RSA-SM4-GCM-SHA256
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -287,40 +322,40 @@ Method = NTLS
 
 # ===========================================================
 
-[8-test ntls client doing handshake without setting certs and pkey]
-ssl_conf = 8-test ntls client doing handshake without setting certs and pkey-ssl
+[9-test ntls client doing handshake without setting certs and pkey]
+ssl_conf = 9-test ntls client doing handshake without setting certs and pkey-ssl
 
-[8-test ntls client doing handshake without setting certs and pkey-ssl]
-server = 8-test ntls client doing handshake without setting certs and pkey-server
-client = 8-test ntls client doing handshake without setting certs and pkey-client
+[9-test ntls client doing handshake without setting certs and pkey-ssl]
+server = 9-test ntls client doing handshake without setting certs and pkey-server
+client = 9-test ntls client doing handshake without setting certs and pkey-client
 
-[8-test ntls client doing handshake without setting certs and pkey-server]
+[9-test ntls client doing handshake without setting certs and pkey-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[8-test ntls client doing handshake without setting certs and pkey-client]
+[9-test ntls client doing handshake without setting certs and pkey-client]
 CipherString = ECC-SM2-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-8]
+[test-9]
 ExpectedResult = ServerFail
 Method = NTLS
 
 
 # ===========================================================
 
-[9-test server encryption certificate expired]
-ssl_conf = 9-test server encryption certificate expired-ssl
+[10-test server encryption certificate expired]
+ssl_conf = 10-test server encryption certificate expired-ssl
 
-[9-test server encryption certificate expired-ssl]
-server = 9-test server encryption certificate expired-server
-client = 9-test server encryption certificate expired-client
+[10-test server encryption certificate expired-ssl]
+server = 10-test server encryption certificate expired-server
+client = 10-test server encryption certificate expired-client
 
-[9-test server encryption certificate expired-server]
+[10-test server encryption certificate expired-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
@@ -330,38 +365,7 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 
-[9-test server encryption certificate expired-client]
-CipherString = DEFAULT
-Enable_ntls = on
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
-VerifyMode = Peer
-
-[test-9]
-ExpectedClientAlert = CertificateExpired
-ExpectedResult = ClientFail
-Method = NTLS
-
-
-# ===========================================================
-
-[10-test server sign certificate expired]
-ssl_conf = 10-test server sign certificate expired-ssl
-
-[10-test server sign certificate expired-ssl]
-server = 10-test server sign certificate expired-server
-client = 10-test server sign certificate expired-client
-
-[10-test server sign certificate expired-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Enable_ntls = on
-EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.crt
-EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
-PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
-SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign_expire.crt
-SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
-
-[10-test server sign certificate expired-client]
+[10-test server encryption certificate expired-client]
 CipherString = DEFAULT
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
@@ -375,24 +379,24 @@ Method = NTLS
 
 # ===========================================================
 
-[11-test server certificates expired]
-ssl_conf = 11-test server certificates expired-ssl
+[11-test server sign certificate expired]
+ssl_conf = 11-test server sign certificate expired-ssl
 
-[11-test server certificates expired-ssl]
-server = 11-test server certificates expired-server
-client = 11-test server certificates expired-client
+[11-test server sign certificate expired-ssl]
+server = 11-test server sign certificate expired-server
+client = 11-test server sign certificate expired-client
 
-[11-test server certificates expired-server]
+[11-test server sign certificate expired-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Enable_ntls = on
-EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_enc_expire.crt
+EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.crt
 EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign_expire.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 
-[11-test server certificates expired-client]
+[11-test server sign certificate expired-client]
 CipherString = DEFAULT
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
@@ -406,14 +410,45 @@ Method = NTLS
 
 # ===========================================================
 
-[12-test server choose ECC-SM2-SM4 with SM2 double certs only]
-ssl_conf = 12-test server choose ECC-SM2-SM4 with SM2 double certs only-ssl
+[12-test server certificates expired]
+ssl_conf = 12-test server certificates expired-ssl
 
-[12-test server choose ECC-SM2-SM4 with SM2 double certs only-ssl]
-server = 12-test server choose ECC-SM2-SM4 with SM2 double certs only-server
-client = 12-test server choose ECC-SM2-SM4 with SM2 double certs only-client
+[12-test server certificates expired-ssl]
+server = 12-test server certificates expired-server
+client = 12-test server certificates expired-client
 
-[12-test server choose ECC-SM2-SM4 with SM2 double certs only-server]
+[12-test server certificates expired-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Enable_ntls = on
+EncCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_enc_expire.crt
+EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign_expire.crt
+SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
+
+[12-test server certificates expired-client]
+CipherString = DEFAULT
+Enable_ntls = on
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
+VerifyMode = Peer
+
+[test-12]
+ExpectedClientAlert = CertificateExpired
+ExpectedResult = ClientFail
+Method = NTLS
+
+
+# ===========================================================
+
+[13-test server choose ECC-SM2-SM4 with SM2 double certs only]
+ssl_conf = 13-test server choose ECC-SM2-SM4 with SM2 double certs only-ssl
+
+[13-test server choose ECC-SM2-SM4 with SM2 double certs only-ssl]
+server = 13-test server choose ECC-SM2-SM4 with SM2 double certs only-server
+client = 13-test server choose ECC-SM2-SM4 with SM2 double certs only-client
+
+[13-test server choose ECC-SM2-SM4 with SM2 double certs only-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = RSA-SM4-CBC-SM3:ECC-SM2-SM4-CBC-SM3
 Enable_ntls = on
@@ -423,13 +458,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 
-[12-test server choose ECC-SM2-SM4 with SM2 double certs only-client]
+[13-test server choose ECC-SM2-SM4 with SM2 double certs only-client]
 CipherString = ECC-SM2-SM4-CBC-SM3:RSA-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
 VerifyMode = Peer
 
-[test-12]
+[test-13]
 ExpectedCipher = ECC-SM2-SM4-CBC-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -438,14 +473,14 @@ Method = NTLS
 
 # ===========================================================
 
-[13-test server choose RSA-SM4 with RSA double certs only]
-ssl_conf = 13-test server choose RSA-SM4 with RSA double certs only-ssl
+[14-test server choose RSA-SM4 with RSA double certs only]
+ssl_conf = 14-test server choose RSA-SM4 with RSA double certs only-ssl
 
-[13-test server choose RSA-SM4 with RSA double certs only-ssl]
-server = 13-test server choose RSA-SM4 with RSA double certs only-server
-client = 13-test server choose RSA-SM4 with RSA double certs only-client
+[14-test server choose RSA-SM4 with RSA double certs only-ssl]
+server = 14-test server choose RSA-SM4 with RSA double certs only-server
+client = 14-test server choose RSA-SM4 with RSA double certs only-client
 
-[13-test server choose RSA-SM4 with RSA double certs only-server]
+[14-test server choose RSA-SM4 with RSA double certs only-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ECC-SM2-SM4-CBC-SM3:RSA-SM4-CBC-SM3
 Enable_ntls = on
@@ -455,13 +490,13 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 SignCertificate = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.crt
 SignPrivateKey = ${ENV::TEST_CERTS_DIR}/server-rsa-sign.key
 
-[13-test server choose RSA-SM4 with RSA double certs only-client]
+[14-test server choose RSA-SM4 with RSA double certs only-client]
 CipherString = ECC-SM2-SM4-CBC-SM3:RSA-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Peer
 
-[test-13]
+[test-14]
 ExpectedCipher = RSA-SM4-CBC-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -470,14 +505,14 @@ Method = NTLS
 
 # ===========================================================
 
-[14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs]
-ssl_conf = 14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-ssl
+[15-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs]
+ssl_conf = 15-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-ssl
 
-[14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-ssl]
-server = 14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-server
-client = 14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-client
+[15-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-ssl]
+server = 15-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-server
+client = 15-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-client
 
-[14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-server]
+[15-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = ECC-SM2-SM4-CBC-SM3:RSA-SM4-CBC-SM3
 Enable_ntls = on
@@ -492,13 +527,13 @@ SM2.EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
 SM2.SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SM2.SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 
-[14-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-client]
+[15-test server choose the preferred cipher ECC-SM2 with SM2 and RSA double certs-client]
 CipherString = RSA-SM4-CBC-SM3:ECC-SM2-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
 VerifyMode = Peer
 
-[test-14]
+[test-15]
 ExpectedCipher = ECC-SM2-SM4-CBC-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -507,14 +542,14 @@ Method = NTLS
 
 # ===========================================================
 
-[15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs]
-ssl_conf = 15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-ssl
+[16-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs]
+ssl_conf = 16-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-ssl
 
-[15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-ssl]
-server = 15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-server
-client = 15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-client
+[16-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-ssl]
+server = 16-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-server
+client = 16-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-client
 
-[15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-server]
+[16-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = RSA-SM4-CBC-SM3:ECC-SM2-SM4-CBC-SM3
 Enable_ntls = on
@@ -529,13 +564,13 @@ SM2.EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
 SM2.SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SM2.SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 
-[15-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-client]
+[16-test server choose the preferred cipher RSA-SM4 with SM2 and RSA double certs-client]
 CipherString = ECC-SM2-SM4-CBC-SM3:RSA-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Peer
 
-[test-15]
+[test-16]
 ExpectedCipher = RSA-SM4-CBC-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success
@@ -544,14 +579,14 @@ Method = NTLS
 
 # ===========================================================
 
-[16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs]
-ssl_conf = 16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-ssl
+[17-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs]
+ssl_conf = 17-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-ssl
 
-[16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-ssl]
-server = 16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-server
-client = 16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-client
+[17-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-ssl]
+server = 17-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-server
+client = 17-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-client
 
-[16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-server]
+[17-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = RSA-SM4-CBC-SM3:ECC-SM2-SM4-CBC-SM3
 Enable_ntls = on
@@ -565,13 +600,13 @@ SM2.EncPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_enc.key
 SM2.SignCertificate = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.crt
 SM2.SignPrivateKey = ${ENV::TEST_CERTS_DIR}/sm2/server_sign.key
 
-[16-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-client]
+[17-test server choose the client preferred cipher RSA-SM4 with SM2 and RSA double certs-client]
 CipherString = ECC-SM2-SM4-CBC-SM3:RSA-SM4-CBC-SM3
 Enable_ntls = on
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2/chain-ca.crt
 VerifyMode = Peer
 
-[test-16]
+[test-17]
 ExpectedCipher = ECC-SM2-SM4-CBC-SM3
 ExpectedProtocol = NTLS
 ExpectedResult = Success

--- a/test/ssl-tests/31-ntls.cnf.in
+++ b/test/ssl-tests/31-ntls.cnf.in
@@ -17,6 +17,30 @@ use OpenSSL::Test::Utils;
 our @tests = (
 
     {
+        name => "test server set min and max TLS version should not affect NTLS",
+        server => {
+            "SignCertificate" => test_pem("sm2", "server_sign.crt"),
+            "SignPrivateKey" => test_pem("sm2", "server_sign.key"),
+            "EncCertificate" => test_pem("sm2", "server_enc.crt"),
+            "EncPrivateKey" => test_pem("sm2", "server_enc.key"),
+            "Enable_ntls" => "on",
+            "MinProtocol" => "TLSv1.2",
+            "MaxProtocol" => "TLSv1.3"
+        },
+        client => {
+            "CipherString" => "ECC-SM2-SM4-CBC-SM3",
+            "VerifyCAFile" => test_pem("sm2", "chain-ca.crt"),
+            "Enable_ntls" => "on",
+        },
+        test   => {
+            "Method" => "NTLS",
+            "ExpectedResult" => "Success",
+            "ExpectedCipher" => "ECC-SM2-SM4-CBC-SM3",
+            "ExpectedProtocol" => "NTLS",
+        },
+    },
+
+    {
         name => "test cipher ECC-SM2-SM4-CBC-SM3 in NTLS_UNIQUE mode, NTLS_UNIQUE test server and client all use NTLS only",
         server => {
             "SignCertificate" => test_pem("sm2", "server_sign.crt"),

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -497,14 +497,14 @@ static int test_handshake(int idx)
 #endif
 #ifndef OPENSSL_NO_NTLS
     if (test_ctx->method == SSL_TEST_METHOD_NTLS) {
-        server_ctx = SSL_CTX_new_ex(libctx, NULL, NTLS_server_method());
+        server_ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
         if (!TEST_ptr(server_ctx)) {
             goto err;
         }
 
         if (test_ctx->extra.server.servername_callback !=
             SSL_TEST_SERVERNAME_CB_NONE) {
-            if (!TEST_ptr(server2_ctx = SSL_CTX_new_ex(libctx, NULL, NTLS_server_method())))
+            if (!TEST_ptr(server2_ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
                 goto err;
         }
 
@@ -514,7 +514,7 @@ static int test_handshake(int idx)
         }
 
         if (test_ctx->handshake_mode == SSL_TEST_HANDSHAKE_RESUME) {
-            resume_server_ctx = SSL_CTX_new_ex(libctx, NULL, NTLS_server_method());
+            resume_server_ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
             resume_client_ctx = SSL_CTX_new_ex(libctx, NULL, NTLS_client_method());
 
             if (!TEST_ptr(resume_server_ctx)


### PR DESCRIPTION
Fixed #513

Set min and max TLS version should not affect NTLS. NTLS only has v1.1, so it's reasonable for API set_min_proto_version/set_max_proto_version to take effect for TLS only.

Delete useless code about renegotion and SCSV in NTLS.

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [x] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
