### PR TITLE
Fix ClientHello key share ext no curveSM2 when enable TLS1.3 + SM strictly

### DIFF
--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -1716,6 +1716,9 @@ static HANDSHAKE_RESULT *do_handshake_internal(
     SSL_get_peer_signature_type_nid(client.ssl, &ret->server_sign_type);
     SSL_get_peer_signature_type_nid(server.ssl, &ret->client_sign_type);
 
+    if (SSL_IS_TLS13(client.ssl) && client.ssl->s3.did_kex)
+        ret->client_key_share = SSL_get_negotiated_group(client.ssl);
+
     names = SSL_get0_peer_CA_list(client.ssl);
     if (names == NULL)
         ret->client_ca_names = NULL;

--- a/test/helpers/handshake.h
+++ b/test/helpers/handshake.h
@@ -70,6 +70,8 @@ typedef struct handshake_result {
     int client_sign_hash;
     /* client signature type */
     int client_sign_type;
+    /* client key share */
+    int client_key_share;
     /* Client CA names */
     STACK_OF(X509_NAME) *client_ca_names;
     /* Session id status */

--- a/test/helpers/ssl_test_ctx.c
+++ b/test/helpers/ssl_test_ctx.c
@@ -13,6 +13,7 @@
 #include <openssl/crypto.h>
 
 #include "internal/nelem.h"
+#include "../../ssl/ssl_local.h"
 #include "ssl_test_ctx.h"
 #include "../testutil.h"
 
@@ -636,6 +637,22 @@ __owur static int parse_expected_sign_hash(int *ptype, const char *value)
     return 1;
 }
 
+__owur static int parse_expected_key_share(int *ptype, const char *value)
+{
+    int nid;
+
+    if (value == NULL)
+        return 0;
+    nid = OBJ_sn2nid(value);
+    if (nid == NID_undef)
+        nid = OBJ_ln2nid(value);
+    if (nid == NID_undef)
+        return 0;
+
+    *ptype = nid;
+    return 1;
+}
+
 __owur static int parse_expected_server_sign_hash(SSL_TEST_CTX *test_ctx,
                                                   const char *value)
 {
@@ -647,6 +664,13 @@ __owur static int parse_expected_client_sign_hash(SSL_TEST_CTX *test_ctx,
                                                   const char *value)
 {
     return parse_expected_sign_hash(&test_ctx->expected_client_sign_hash,
+                                    value);
+}
+
+__owur static int parse_expected_client_key_share(SSL_TEST_CTX *test_ctx,
+                                                  const char *value)
+{
+    return parse_expected_key_share(&test_ctx->expected_client_key_share,
                                     value);
 }
 
@@ -737,6 +761,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ExpectedClientSignHash", &parse_expected_client_sign_hash },
     { "ExpectedClientSignType", &parse_expected_client_sign_type },
     { "ExpectedClientCANames", &parse_expected_client_ca_names },
+    { "ExpectedClientKeyShare", &parse_expected_client_key_share },
     { "UseSCTP", &parse_test_use_sctp },
     { "EnableClientSCTPLabelBug", &parse_test_enable_client_sctp_label_bug },
     { "EnableServerSCTPLabelBug", &parse_test_enable_server_sctp_label_bug },

--- a/test/helpers/ssl_test_ctx.h
+++ b/test/helpers/ssl_test_ctx.h
@@ -233,6 +233,8 @@ typedef struct {
     int expected_client_sign_type;
     /* Expected CA names for client auth */
     STACK_OF(X509_NAME) *expected_client_ca_names;
+    /* Expected client key share */
+    int expected_client_key_share;
     /* Whether to use SCTP for the transport */
     int use_sctp;
     /* Enable SSL_MODE_DTLS_SCTP_LABEL_LENGTH_BUG on client side */

--- a/test/ssl-tests/30-tls13-sm.cnf
+++ b/test/ssl-tests/30-tls13-sm.cnf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 23
+num_tests = 22
 
 test-0 = 0-test ciphersuites TLS_SM4_GCM_SM3
 test-1 = 1-test series of ciphersuites includes TLS_SM4_GCM_SM3
@@ -17,14 +17,13 @@ test-11 = 11-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable
 test-12 = 12-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag
 test-13 = 13-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag
 test-14 = 14-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain
-test-15 = 15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3
-test-16 = 16-test client should fail when enable sm_tls13_strict without SM2 key_share
-test-17 = 17-test client success when enable sm_tls13_strict with SM2 key_share
-test-18 = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher
-test-19 = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3
-test-20 = 20-test client auth success when both enable sm_tls13_strict
-test-21 = 21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3
-test-22 = 22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3
+test-15 = 15-test client enable sm_tls13_strict, the key_share extension must include curveSM2
+test-16 = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3
+test-17 = 17-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher
+test-18 = 18-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3
+test-19 = 19-test client auth success when also enable sm_tls13_strict
+test-20 = 20-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3
+test-21 = 21-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3
 # ===========================================================
 
 [0-test ciphersuites TLS_SM4_GCM_SM3]
@@ -481,25 +480,26 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3]
-ssl_conf = 15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl
+[15-test client enable sm_tls13_strict, the key_share extension must include curveSM2]
+ssl_conf = 15-test client enable sm_tls13_strict, the key_share extension must include curveSM2-ssl
 
-[15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl]
-server = 15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server
-client = 15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client
+[15-test client enable sm_tls13_strict, the key_share extension must include curveSM2-ssl]
+server = 15-test client enable sm_tls13_strict, the key_share extension must include curveSM2-server
+client = 15-test client enable sm_tls13_strict, the key_share extension must include curveSM2-client
 
-[15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server]
+[15-test client enable sm_tls13_strict, the key_share extension must include curveSM2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
+Enable_sm_tls13_strict = off
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 
-[15-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client]
+[15-test client enable sm_tls13_strict, the key_share extension must include curveSM2-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
@@ -507,70 +507,37 @@ VerifyMode = Peer
 
 [test-15]
 ExpectedCipher = TLS_SM4_GCM_SM3
-ExpectedHRR = Yes
+ExpectedClientKeyShare = SM2
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[16-test client should fail when enable sm_tls13_strict without SM2 key_share]
-ssl_conf = 16-test client should fail when enable sm_tls13_strict without SM2 key_share-ssl
+[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3]
+ssl_conf = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl
 
-[16-test client should fail when enable sm_tls13_strict without SM2 key_share-ssl]
-server = 16-test client should fail when enable sm_tls13_strict without SM2 key_share-server
-client = 16-test client should fail when enable sm_tls13_strict without SM2 key_share-client
+[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl]
+server = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server
+client = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client
 
-[16-test client should fail when enable sm_tls13_strict without SM2 key_share-server]
+[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = off
+Enable_sm_tls13_strict = on
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 
-[16-test client should fail when enable sm_tls13_strict without SM2 key_share-client]
+[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
 [test-16]
-ExpectedResult = ClientFail
-
-
-# ===========================================================
-
-[17-test client success when enable sm_tls13_strict with SM2 key_share]
-ssl_conf = 17-test client success when enable sm_tls13_strict with SM2 key_share-ssl
-
-[17-test client success when enable sm_tls13_strict with SM2 key_share-ssl]
-server = 17-test client success when enable sm_tls13_strict with SM2 key_share-server
-client = 17-test client success when enable sm_tls13_strict with SM2 key_share-client
-
-[17-test client success when enable sm_tls13_strict with SM2 key_share-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = off
-Groups = SM2
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
-
-[17-test client success when enable sm_tls13_strict with SM2 key_share-client]
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
-VerifyMode = Peer
-
-[test-17]
 ExpectedCipher = TLS_SM4_GCM_SM3
 ExpectedHRR = Yes
 ExpectedResult = Success
@@ -578,14 +545,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher]
-ssl_conf = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl
+[17-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher]
+ssl_conf = 17-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl
 
-[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl]
-server = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server
-client = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client
+[17-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl]
+server = 17-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server
+client = 17-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client
 
-[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server]
+[17-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -595,7 +562,7 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
 
-[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client]
+[17-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 Enable_sm_tls13_strict = on
@@ -604,21 +571,21 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-18]
+[test-17]
 ExpectedClientAlert = BadCertificate
 ExpectedResult = ClientFail
 
 
 # ===========================================================
 
-[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3]
-ssl_conf = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl
+[18-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3]
+ssl_conf = 18-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl
 
-[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl]
-server = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server
-client = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client
+[18-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl]
+server = 18-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server
+client = 18-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client
 
-[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server]
+[18-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -630,7 +597,42 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root-cert.pem
 VerifyMode = Require
 
-[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client]
+[18-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
+VerifyMode = Peer
+
+[test-18]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[19-test client auth success when also enable sm_tls13_strict]
+ssl_conf = 19-test client auth success when also enable sm_tls13_strict-ssl
+
+[19-test client auth success when also enable sm_tls13_strict-ssl]
+server = 19-test client auth success when also enable sm_tls13_strict-server
+client = 19-test client auth success when also enable sm_tls13_strict-client
+
+[19-test client auth success when also enable sm_tls13_strict-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root-cert.pem
+VerifyMode = Require
+
+[19-test client auth success when also enable sm_tls13_strict-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -642,56 +644,20 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
 [test-19]
-ExpectedResult = ClientFail
-
-
-# ===========================================================
-
-[20-test client auth success when both enable sm_tls13_strict]
-ssl_conf = 20-test client auth success when both enable sm_tls13_strict-ssl
-
-[20-test client auth success when both enable sm_tls13_strict-ssl]
-server = 20-test client auth success when both enable sm_tls13_strict-server
-client = 20-test client auth success when both enable sm_tls13_strict-client
-
-[20-test client auth success when both enable sm_tls13_strict-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root-cert.pem
-VerifyMode = Require
-
-[20-test client auth success when both enable sm_tls13_strict-client]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
-VerifyMode = Peer
-
-[test-20]
 ExpectedCipher = TLS_SM4_GCM_SM3
-ExpectedHRR = Yes
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3]
-ssl_conf = 21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl
+[20-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3]
+ssl_conf = 20-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl
 
-[21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl]
-server = 21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server
-client = 21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client
+[20-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl]
+server = 20-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server
+client = 20-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client
 
-[21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server]
+[20-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -706,7 +672,7 @@ SM2.PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root-cert.pem
 VerifyMode = Require
 
-[21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client]
+[20-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -718,7 +684,7 @@ SignatureAlgorithms = rsa_pss_rsae_sha256:sm2sig_sm3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
-[test-21]
+[test-20]
 ExpectedCipher = TLS_SM4_GCM_SM3
 ExpectedResult = Success
 ExpectedServerCertType = SM2
@@ -726,14 +692,14 @@ ExpectedServerCertType = SM2
 
 # ===========================================================
 
-[22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3]
-ssl_conf = 22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl
+[21-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3]
+ssl_conf = 21-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl
 
-[22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl]
-server = 22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server
-client = 22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client
+[21-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl]
+server = 21-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server
+client = 21-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client
 
-[22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server]
+[21-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -746,7 +712,7 @@ SignatureAlgorithms = rsa_pss_rsae_sha256:sm2sig_sm3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root-cert.pem
 VerifyMode = Require
 
-[22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client]
+[21-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 Enable_sm_tls13_strict = on
@@ -759,7 +725,7 @@ SM2.PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
-[test-22]
+[test-21]
 ExpectedClientAlert = IllegalParameter
 ExpectedResult = ClientFail
 

--- a/test/ssl-tests/30-tls13-sm.cnf.in
+++ b/test/ssl-tests/30-tls13-sm.cnf.in
@@ -328,6 +328,30 @@ our @tests = (
     },
 
     {
+        name => "test client enable sm_tls13_strict, the key_share extension must include curveSM2",
+        server => {
+            "MinProtocol" => "TLSv1.3",
+            "MaxProtocol" => "TLSv1.3",
+            "Ciphersuites" => "TLS_SM4_GCM_SM3",
+            "Certificate" => test_pem("sm2-leaf.crt"),
+            "PrivateKey" => test_pem("sm2-leaf.key"),
+            "Enable_sm_tls13_strict" => "off",
+        },
+        client => {
+            "MinProtocol" => "TLSv1.3",
+            "MaxProtocol" => "TLSv1.3",
+            "Ciphersuites" => "TLS_SM4_GCM_SM3",
+            "VerifyCAFile" => test_pem("sm2-chain-ca.crt"),
+            "Enable_sm_tls13_strict" => "on",
+        },
+        test   => {
+            "ExpectedResult" => "Success",
+            "ExpectedCipher" => "TLS_SM4_GCM_SM3",
+            "ExpectedClientKeyShare" => "SM2",
+        },
+    },
+
+    {
         name => "test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3",
         server => {
             "MinProtocol" => "TLSv1.3",
@@ -343,53 +367,6 @@ our @tests = (
             "MaxProtocol" => "TLSv1.3",
             "Ciphersuites" => "TLS_SM4_GCM_SM3",
             "VerifyCAFile" => test_pem("sm2-chain-ca.crt"),
-        },
-        test   => {
-            "ExpectedResult" => "Success",
-            "ExpectedCipher" => "TLS_SM4_GCM_SM3",
-            "ExpectedHRR" => "Yes",
-        },
-    },
-
-    {
-        name => "test client should fail when enable sm_tls13_strict without SM2 key_share",
-        server => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_SM4_GCM_SM3",
-            "Certificate" => test_pem("sm2-leaf.crt"),
-            "PrivateKey" => test_pem("sm2-leaf.key"),
-            "Enable_sm_tls13_strict" => "off",
-        },
-        client => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_SM4_GCM_SM3",
-            "VerifyCAFile" => test_pem("sm2-chain-ca.crt"),
-            "Enable_sm_tls13_strict" => "on",
-        },
-        test   => {
-            "ExpectedResult" => "ClientFail",
-        },
-    },
-
-    {
-        name => "test client success when enable sm_tls13_strict with SM2 key_share",
-        server => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_SM4_GCM_SM3",
-            "Certificate" => test_pem("sm2-leaf.crt"),
-            "PrivateKey" => test_pem("sm2-leaf.key"),
-            "Enable_sm_tls13_strict" => "off",
-            "Groups" => "SM2",
-        },
-        client => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_SM4_GCM_SM3",
-            "VerifyCAFile" => test_pem("sm2-chain-ca.crt"),
-            "Enable_sm_tls13_strict" => "on",
         },
         test   => {
             "ExpectedResult" => "Success",
@@ -449,7 +426,7 @@ our @tests = (
     },
 
     {
-        name => "test client auth success when both enable sm_tls13_strict",
+        name => "test client auth success when also enable sm_tls13_strict",
         server => {
             "MinProtocol" => "TLSv1.3",
             "MaxProtocol" => "TLSv1.3",
@@ -472,7 +449,6 @@ our @tests = (
         test   => {
             "ExpectedResult" => "Success",
             "ExpectedCipher" => "TLS_SM4_GCM_SM3",
-            "ExpectedHRR" => "Yes",
         },
     },
 

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -358,6 +358,18 @@ static int check_client_sign_type(HANDSHAKE_RESULT *result,
                      result->client_sign_type);
 }
 
+static int check_client_key_share(HANDSHAKE_RESULT *result,
+                                  SSL_TEST_CTX *test_ctx)
+{
+    if (test_ctx->expected_client_key_share == 0
+        || test_ctx->expected_client_key_share == result->client_key_share)
+        return 1;
+
+    TEST_error("Client key share type mismatch, %d vs %d\n",
+               test_ctx->expected_client_key_share, result->client_key_share);
+    return 0;
+}
+
 static int check_client_ca_names(HANDSHAKE_RESULT *result,
                                  SSL_TEST_CTX *test_ctx)
 {
@@ -422,6 +434,7 @@ static int check_test(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
         ret &= check_client_cert_type(result, test_ctx);
         ret &= check_client_sign_hash(result, test_ctx);
         ret &= check_client_sign_type(result, test_ctx);
+        ret &= check_client_key_share(result, test_ctx);
         ret &= check_client_ca_names(result, test_ctx);
         ret &= check_hrr(result, test_ctx);
 #ifndef OPENSSL_NO_DELEGATED_CREDENTIAL


### PR DESCRIPTION
Fixed #522

Re-order curveSM2 to the first supported group when enable_sm_tls13_strict is set, so that the key_share extension will include a KeyShareEntry for the "curveSM2" group because only one KeyShareEntry is sent now.

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [x] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
