### PR TITLE
Fix ClientHello key share ext no curveSM2 when enable TLS1.3 + SM strictly

### DIFF
--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2754,6 +2754,7 @@ SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n);
 #  ifndef OPENSSL_NO_EC
 
 __owur const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t curve_id);
+__owur int tls1_group_id2nid(uint16_t group_id, int include_unknown);
 __owur int tls1_check_group_id(SSL *s, uint16_t group_id, int check_own_curves);
 __owur uint16_t tls1_shared_group(SSL *s, int nmatch);
 __owur int tls1_set_groups(uint16_t **pext, size_t *pextlen,

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -177,7 +177,6 @@ EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
 
     if (!use_ecc(s))
         return EXT_RETURN_NOT_SENT;
-
     /*
      * Add TLS extension supported_groups to the ClientHello message
      */
@@ -193,7 +192,69 @@ EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
                  ERR_R_INTERNAL_ERROR);
         return EXT_RETURN_FAIL;
     }
-    /* Copy curve ID if supported */
+
+#ifndef OPENSSL_NO_SM2
+    int min_version, max_version, reason;
+
+    reason = ssl_get_min_max_version(s, &min_version, &max_version, NULL);
+    if (reason != 0) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                 SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS, reason);
+        return EXT_RETURN_FAIL;
+    }
+    /*
+     * RFC 8998 requires that:
+     * For the key_share extension, a KeyShareEntry for the "curveSM2" group
+     * MUST be included. We re-order curveSM2 to the first supported group when
+     * enable_sm_tls13_strict so that the key_share extension will include a
+     * KeyShareEntry for the "curveSM2" group because only one KeyShareEntry is
+     * sent now.
+     */
+    if (!SSL_IS_DTLS(s) && max_version >= TLS1_3_VERSION
+        && s->enable_sm_tls13_strict == 1) {
+        int sm2_idx = -1;
+
+        for (i = 0; i < num_groups; i++) {
+            if (pgroups[i] == TLSEXT_curve_SM2) {
+                sm2_idx = i;
+                break;
+            }
+        }
+
+        if (sm2_idx > 0) {
+            int *groups = OPENSSL_malloc(sizeof(int) * num_groups);
+            if (groups == NULL) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                         SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS,
+                         ERR_R_INTERNAL_ERROR);
+                return EXT_RETURN_FAIL;
+            }
+
+            for (i = 0; i < num_groups; i++)
+                groups[i] = tls1_group_id2nid(pgroups[i], 1);
+
+            for (i = sm2_idx; i > 0; i--)
+                groups[i] = groups[i - 1];
+
+            groups[0] = NID_sm2;
+
+            if (!tls1_set_groups(&s->ext.supportedgroups,
+                                 &s->ext.supportedgroups_len,
+                                 groups, num_groups)) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                         SSL_F_TLS_CONSTRUCT_CTOS_SUPPORTED_GROUPS,
+                         ERR_R_INTERNAL_ERROR);
+                OPENSSL_free(groups);
+                return EXT_RETURN_FAIL;
+            }
+
+            OPENSSL_free(groups);
+            tls1_get_supported_groups(s, &pgroups, &num_groups);
+        }
+    }
+#endif
+
+    /* Copy group ID if supported */
     for (i = 0; i < num_groups; i++) {
         uint16_t ctmp = pgroups[i];
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -237,6 +237,23 @@ const TLS_GROUP_INFO *tls1_group_id_lookup(uint16_t group_id)
     return &nid_list[group_id - 1];
 }
 
+int tls1_group_id2nid(uint16_t group_id, int include_unknown)
+{
+    if (group_id == 0)
+        return NID_undef;
+
+    /*
+     * Return well known Group NIDs - for backwards compatibility. This won't
+     * work for groups we don't know about.
+     */
+    if (group_id <= OSSL_NELEM(nid_list))
+        return nid_list[group_id - 1].nid;
+
+    if (!include_unknown)
+        return NID_undef;
+    return TLSEXT_nid_unknown | (int)group_id;
+}
+
 static uint16_t tls1_nid2group_id(int nid)
 {
     size_t i;
@@ -383,11 +400,7 @@ int tls1_set_groups(uint16_t **pext, size_t *pextlen,
 {
     uint16_t *glist;
     size_t i;
-    /*
-     * Bitmap of groups included to detect duplicates: only works while group
-     * ids < 32
-     */
-    unsigned long dup_list = 0;
+    uint8_t bitmap[64] = { 0 };
 
     if (ngroups == 0) {
         SSLerr(SSL_F_TLS1_SET_GROUPS, SSL_R_BAD_LENGTH);
@@ -398,22 +411,29 @@ int tls1_set_groups(uint16_t **pext, size_t *pextlen,
         return 0;
     }
     for (i = 0; i < ngroups; i++) {
-        unsigned long idmask;
         uint16_t id;
-        /* TODO(TLS1.3): Convert for DH groups */
         id = tls1_nid2group_id(groups[i]);
-        idmask = 1L << id;
-        if (!id || (dup_list & idmask)) {
-            OPENSSL_free(glist);
-            return 0;
+        if (ngroups == 1) {
+            glist[i] = id;
+            break;
         }
-        dup_list |= idmask;
+
+        if (id == 0 || id >= sizeof(bitmap) * 8)
+            goto err;
+
+        if (bitmap[id / 8] & (1 << (id % 8)))
+            goto err;
+
+        bitmap[id / 8] |= 1 << (id % 8);
         glist[i] = id;
     }
     OPENSSL_free(*pext);
     *pext = glist;
     *pextlen = ngroups;
     return 1;
+err:
+    OPENSSL_free(glist);
+    return 0;
 }
 
 # define MAX_CURVELIST   OSSL_NELEM(nid_list)

--- a/test/handshake_helper.c
+++ b/test/handshake_helper.c
@@ -1739,6 +1739,9 @@ static HANDSHAKE_RESULT *do_handshake_internal(
     SSL_get_peer_signature_type_nid(client.ssl, &ret->server_sign_type);
     SSL_get_peer_signature_type_nid(server.ssl, &ret->client_sign_type);
 
+    if (SSL_IS_TLS13(client.ssl))
+        ret->client_key_share = client.ssl->s3->group_id;
+
     names = SSL_get0_peer_CA_list(client.ssl);
     if (names == NULL)
         ret->client_ca_names = NULL;

--- a/test/handshake_helper.h
+++ b/test/handshake_helper.h
@@ -60,6 +60,8 @@ typedef struct handshake_result {
     int client_sign_hash;
     /* client signature type */
     int client_sign_type;
+    /* client key share */
+    int client_key_share;
     /* Client CA names */
     STACK_OF(X509_NAME) *client_ca_names;
     /* Session id status */

--- a/test/ssl-tests/30-tls13-sm.conf
+++ b/test/ssl-tests/30-tls13-sm.conf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 24
+num_tests = 23
 
 test-0 = 0-test ciphersuites TLS_SM4_GCM_SM3
 test-1 = 1-test series of ciphersuites includes TLS_SM4_GCM_SM3
@@ -18,14 +18,13 @@ test-12 = 12-test server can accept TLS_SM4_CCM_SM3 with ecdsa cert when disable
 test-13 = 13-test server can not accept TLS_SM4_CCM_SM3 with rsa cert when enable sm_tls13_strict tag
 test-14 = 14-test server can accept TLS_SM4_CCM_SM3 with rsa cert when disable sm_tls13_strict tag
 test-15 = 15-test server can accept TLS_SM4_CCM_SM3 with long sm2 cert chain
-test-16 = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3
-test-17 = 17-test client should fail when enable sm_tls13_strict without SM2 key_share
-test-18 = 18-test client success when enable sm_tls13_strict with SM2 key_share
-test-19 = 19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher
-test-20 = 20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3
-test-21 = 21-test client auth success when both enable sm_tls13_strict
-test-22 = 22-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3
-test-23 = 23-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3
+test-16 = 16-test client enable sm_tls13_strict, the key_share extension must include curveSM2
+test-17 = 17-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3
+test-18 = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher
+test-19 = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3
+test-20 = 20-test client auth success when also enable sm_tls13_strict
+test-21 = 21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3
+test-22 = 22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3
 # ===========================================================
 
 [0-test ciphersuites TLS_SM4_GCM_SM3]
@@ -512,25 +511,26 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3]
-ssl_conf = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl
+[16-test client enable sm_tls13_strict, the key_share extension must include curveSM2]
+ssl_conf = 16-test client enable sm_tls13_strict, the key_share extension must include curveSM2-ssl
 
-[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl]
-server = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server
-client = 16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client
+[16-test client enable sm_tls13_strict, the key_share extension must include curveSM2-ssl]
+server = 16-test client enable sm_tls13_strict, the key_share extension must include curveSM2-server
+client = 16-test client enable sm_tls13_strict, the key_share extension must include curveSM2-client
 
-[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server]
+[16-test client enable sm_tls13_strict, the key_share extension must include curveSM2-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
+Enable_sm_tls13_strict = off
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 
-[16-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client]
+[16-test client enable sm_tls13_strict, the key_share extension must include curveSM2-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
@@ -538,70 +538,37 @@ VerifyMode = Peer
 
 [test-16]
 ExpectedCipher = TLS_SM4_GCM_SM3
-ExpectedHRR = Yes
+ExpectedClientKeyShare = 41
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[17-test client should fail when enable sm_tls13_strict without SM2 key_share]
-ssl_conf = 17-test client should fail when enable sm_tls13_strict without SM2 key_share-ssl
+[17-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3]
+ssl_conf = 17-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl
 
-[17-test client should fail when enable sm_tls13_strict without SM2 key_share-ssl]
-server = 17-test client should fail when enable sm_tls13_strict without SM2 key_share-server
-client = 17-test client should fail when enable sm_tls13_strict without SM2 key_share-client
+[17-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-ssl]
+server = 17-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server
+client = 17-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client
 
-[17-test client should fail when enable sm_tls13_strict without SM2 key_share-server]
+[17-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = off
+Enable_sm_tls13_strict = on
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 
-[17-test client should fail when enable sm_tls13_strict without SM2 key_share-client]
+[17-test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
 MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
 [test-17]
-ExpectedResult = ClientFail
-
-
-# ===========================================================
-
-[18-test client success when enable sm_tls13_strict with SM2 key_share]
-ssl_conf = 18-test client success when enable sm_tls13_strict with SM2 key_share-ssl
-
-[18-test client success when enable sm_tls13_strict with SM2 key_share-ssl]
-server = 18-test client success when enable sm_tls13_strict with SM2 key_share-server
-client = 18-test client success when enable sm_tls13_strict with SM2 key_share-client
-
-[18-test client success when enable sm_tls13_strict with SM2 key_share-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = off
-Groups = SM2
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
-
-[18-test client success when enable sm_tls13_strict with SM2 key_share-client]
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
-VerifyMode = Peer
-
-[test-18]
 ExpectedCipher = TLS_SM4_GCM_SM3
 ExpectedHRR = Yes
 ExpectedResult = Success
@@ -609,14 +576,14 @@ ExpectedResult = Success
 
 # ===========================================================
 
-[19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher]
-ssl_conf = 19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl
+[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher]
+ssl_conf = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl
 
-[19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl]
-server = 19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server
-client = 19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client
+[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-ssl]
+server = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server
+client = 18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client
 
-[19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server]
+[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-ecdsa-cert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -626,7 +593,7 @@ MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-ecdsa-key.pem
 
-[19-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client]
+[18-test client should fail when enable sm_tls13_strict with ecdsa cert and TLS_SM4_GCM_SM3 cipher-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 Enable_sm_tls13_strict = on
@@ -635,21 +602,21 @@ MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-19]
+[test-18]
 ExpectedClientAlert = BadCertificate
 ExpectedResult = ClientFail
 
 
 # ===========================================================
 
-[20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3]
-ssl_conf = 20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl
+[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3]
+ssl_conf = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl
 
-[20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl]
-server = 20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server
-client = 20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client
+[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-ssl]
+server = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server
+client = 19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client
 
-[20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server]
+[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -661,7 +628,42 @@ PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
 VerifyMode = Require
 
-[20-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client]
+[19-test client auth fail when enable sm_tls13_strict, CertificateRequest with other signature algorithms except sm2sig_sm3-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
+VerifyMode = Peer
+
+[test-19]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[20-test client auth success when also enable sm_tls13_strict]
+ssl_conf = 20-test client auth success when also enable sm_tls13_strict-ssl
+
+[20-test client auth success when also enable sm_tls13_strict-ssl]
+server = 20-test client auth success when also enable sm_tls13_strict-server
+client = 20-test client auth success when also enable sm_tls13_strict-client
+
+[20-test client auth success when also enable sm_tls13_strict-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
+CipherString = DEFAULT
+Ciphersuites = TLS_SM4_GCM_SM3
+Enable_sm_tls13_strict = on
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
+VerifyMode = Require
+
+[20-test client auth success when also enable sm_tls13_strict-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -673,56 +675,20 @@ VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
 [test-20]
-ExpectedResult = ClientFail
-
-
-# ===========================================================
-
-[21-test client auth success when both enable sm_tls13_strict]
-ssl_conf = 21-test client auth success when both enable sm_tls13_strict-ssl
-
-[21-test client auth success when both enable sm_tls13_strict-ssl]
-server = 21-test client auth success when both enable sm_tls13_strict-server
-client = 21-test client auth success when both enable sm_tls13_strict-client
-
-[21-test client auth success when both enable sm_tls13_strict-server]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
-VerifyMode = Require
-
-[21-test client auth success when both enable sm_tls13_strict-client]
-Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
-CipherString = DEFAULT
-Ciphersuites = TLS_SM4_GCM_SM3
-Enable_sm_tls13_strict = on
-MaxProtocol = TLSv1.3
-MinProtocol = TLSv1.3
-PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
-VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
-VerifyMode = Peer
-
-[test-21]
 ExpectedCipher = TLS_SM4_GCM_SM3
-ExpectedHRR = Yes
 ExpectedResult = Success
 
 
 # ===========================================================
 
-[22-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3]
-ssl_conf = 22-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl
+[21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3]
+ssl_conf = 21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl
 
-[22-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl]
-server = 22-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server
-client = 22-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client
+[21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl]
+server = 21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server
+client = 21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client
 
-[22-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server]
+[21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -737,7 +703,7 @@ SM2.PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-leaf.key
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
 VerifyMode = Require
 
-[22-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client]
+[21-test sm_tls13_strict server with sm2 and rsa certs, client signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-first-crt.pem
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -749,7 +715,7 @@ SignatureAlgorithms = rsa_pss_rsae_sha256:sm2sig_sm3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
-[test-22]
+[test-21]
 ExpectedCipher = TLS_SM4_GCM_SM3
 ExpectedResult = Success
 ExpectedServerCertType = SM2
@@ -757,14 +723,14 @@ ExpectedServerCertType = SM2
 
 # ===========================================================
 
-[23-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3]
-ssl_conf = 23-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl
+[22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3]
+ssl_conf = 22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl
 
-[23-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl]
-server = 23-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server
-client = 23-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client
+[22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-ssl]
+server = 22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server
+client = 22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client
 
-[23-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server]
+[22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/sm2-leaf.crt
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
@@ -777,7 +743,7 @@ SignatureAlgorithms = rsa_pss_rsae_sha256:sm2sig_sm3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-root.crt
 VerifyMode = Require
 
-[23-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client]
+[22-test sm_tls13_strict client with sm2 and rsa certs, server signature_algorithms with rsa_pss_rsae_sha256 and sm2sig_sm3-client]
 CipherString = DEFAULT
 Ciphersuites = TLS_SM4_GCM_SM3
 Enable_sm_tls13_strict = on
@@ -790,7 +756,7 @@ SM2.PrivateKey = ${ENV::TEST_CERTS_DIR}/sm2-first-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/sm2-chain-ca.crt
 VerifyMode = Peer
 
-[test-23]
+[test-22]
 ExpectedClientAlert = IllegalParameter
 ExpectedResult = ClientFail
 

--- a/test/ssl-tests/30-tls13-sm.conf.in
+++ b/test/ssl-tests/30-tls13-sm.conf.in
@@ -338,6 +338,30 @@ our @tests = (
     },
 
     {
+        name => "test client enable sm_tls13_strict, the key_share extension must include curveSM2",
+        server => {
+            "MinProtocol" => "TLSv1.3",
+            "MaxProtocol" => "TLSv1.3",
+            "Ciphersuites" => "TLS_SM4_GCM_SM3",
+            "Certificate" => test_pem("sm2-leaf.crt"),
+            "PrivateKey" => test_pem("sm2-leaf.key"),
+            "Enable_sm_tls13_strict" => "off",
+        },
+        client => {
+            "MinProtocol" => "TLSv1.3",
+            "MaxProtocol" => "TLSv1.3",
+            "Ciphersuites" => "TLS_SM4_GCM_SM3",
+            "VerifyCAFile" => test_pem("sm2-chain-ca.crt"),
+            "Enable_sm_tls13_strict" => "on",
+        },
+        test   => {
+            "ExpectedResult" => "Success",
+            "ExpectedCipher" => "TLS_SM4_GCM_SM3",
+            "ExpectedClientKeyShare" => "41",
+        },
+    },
+
+    {
         name => "test ClientHello1 no SM2 key_share, server should send HRR when enable sm_tls13_strict and choose TLS_SM4_GCM_SM3",
         server => {
             "MinProtocol" => "TLSv1.3",
@@ -353,53 +377,6 @@ our @tests = (
             "MaxProtocol" => "TLSv1.3",
             "Ciphersuites" => "TLS_SM4_GCM_SM3",
             "VerifyCAFile" => test_pem("sm2-chain-ca.crt"),
-        },
-        test   => {
-            "ExpectedResult" => "Success",
-            "ExpectedCipher" => "TLS_SM4_GCM_SM3",
-            "ExpectedHRR" => "Yes",
-        },
-    },
-
-    {
-        name => "test client should fail when enable sm_tls13_strict without SM2 key_share",
-        server => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_SM4_GCM_SM3",
-            "Certificate" => test_pem("sm2-leaf.crt"),
-            "PrivateKey" => test_pem("sm2-leaf.key"),
-            "Enable_sm_tls13_strict" => "off",
-        },
-        client => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_SM4_GCM_SM3",
-            "VerifyCAFile" => test_pem("sm2-chain-ca.crt"),
-            "Enable_sm_tls13_strict" => "on",
-        },
-        test   => {
-            "ExpectedResult" => "ClientFail",
-        },
-    },
-
-    {
-        name => "test client success when enable sm_tls13_strict with SM2 key_share",
-        server => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_SM4_GCM_SM3",
-            "Certificate" => test_pem("sm2-leaf.crt"),
-            "PrivateKey" => test_pem("sm2-leaf.key"),
-            "Enable_sm_tls13_strict" => "off",
-            "Groups" => "SM2",
-        },
-        client => {
-            "MinProtocol" => "TLSv1.3",
-            "MaxProtocol" => "TLSv1.3",
-            "Ciphersuites" => "TLS_SM4_GCM_SM3",
-            "VerifyCAFile" => test_pem("sm2-chain-ca.crt"),
-            "Enable_sm_tls13_strict" => "on",
         },
         test   => {
             "ExpectedResult" => "Success",
@@ -459,7 +436,7 @@ our @tests = (
     },
 
     {
-        name => "test client auth success when both enable sm_tls13_strict",
+        name => "test client auth success when also enable sm_tls13_strict",
         server => {
             "MinProtocol" => "TLSv1.3",
             "MaxProtocol" => "TLSv1.3",
@@ -482,7 +459,6 @@ our @tests = (
         test   => {
             "ExpectedResult" => "Success",
             "ExpectedCipher" => "TLS_SM4_GCM_SM3",
-            "ExpectedHRR" => "Yes",
         },
     },
 

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -355,6 +355,18 @@ static int check_client_sign_type(HANDSHAKE_RESULT *result,
                      result->client_sign_type);
 }
 
+static int check_client_key_share(HANDSHAKE_RESULT *result,
+                                  SSL_TEST_CTX *test_ctx)
+{
+    if (test_ctx->expected_client_key_share == 0
+        || test_ctx->expected_client_key_share == result->client_key_share)
+        return 1;
+
+    TEST_error("Client key share type mismatch, %d vs %d\n",
+               test_ctx->expected_client_key_share, result->client_key_share);
+    return 0;
+}
+
 static int check_client_ca_names(HANDSHAKE_RESULT *result,
                                  SSL_TEST_CTX *test_ctx)
 {
@@ -420,6 +432,7 @@ static int check_test(HANDSHAKE_RESULT *result, SSL_TEST_CTX *test_ctx)
         ret &= check_client_cert_type(result, test_ctx);
         ret &= check_client_sign_hash(result, test_ctx);
         ret &= check_client_sign_type(result, test_ctx);
+        ret &= check_client_key_share(result, test_ctx);
         ret &= check_client_ca_names(result, test_ctx);
 #ifndef OPENSSL_NO_DELEGATED_CREDENTIAL
         ret &= check_client_dc_usage(result, test_ctx);

--- a/test/ssl_test_ctx.c
+++ b/test/ssl_test_ctx.c
@@ -637,6 +637,15 @@ __owur static int parse_expected_sign_hash(int *ptype, const char *value)
     return 1;
 }
 
+__owur static int parse_expected_key_share(int *ptype, const char *value)
+{
+    if (value == NULL)
+        return 0;
+
+    *ptype = atoi(value);
+    return 1;
+}
+
 __owur static int parse_expected_server_sign_hash(SSL_TEST_CTX *test_ctx,
                                                   const char *value)
 {
@@ -648,6 +657,13 @@ __owur static int parse_expected_client_sign_hash(SSL_TEST_CTX *test_ctx,
                                                   const char *value)
 {
     return parse_expected_sign_hash(&test_ctx->expected_client_sign_hash,
+                                    value);
+}
+
+__owur static int parse_expected_client_key_share(SSL_TEST_CTX *test_ctx,
+                                                  const char *value)
+{
+    return parse_expected_key_share(&test_ctx->expected_client_key_share,
                                     value);
 }
 
@@ -734,6 +750,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ExpectedClientSignHash", &parse_expected_client_sign_hash },
     { "ExpectedClientSignType", &parse_expected_client_sign_type },
     { "ExpectedClientCANames", &parse_expected_client_ca_names },
+    { "ExpectedClientKeyShare", &parse_expected_client_key_share },
     { "UseSCTP", &parse_test_use_sctp },
     { "EnableClientSCTPLabelBug", &parse_test_enable_client_sctp_label_bug },
     { "EnableServerSCTPLabelBug", &parse_test_enable_server_sctp_label_bug },

--- a/test/ssl_test_ctx.h
+++ b/test/ssl_test_ctx.h
@@ -230,6 +230,8 @@ typedef struct {
     int expected_client_sign_type;
     /* Expected CA names for client auth */
     STACK_OF(X509_NAME) *expected_client_ca_names;
+    /* Expected client key share */
+    int expected_client_key_share;
     /* Whether to use SCTP for the transport */
     int use_sctp;
     /* Enable SSL_MODE_DTLS_SCTP_LABEL_LENGTH_BUG on client side */


### PR DESCRIPTION
Fixed #522

Re-order curveSM2 to the first supported group when enable_sm_tls13_strict is set, so that the key_share extension will include a KeyShareEntry for the "curveSM2" group because only one KeyShareEntry is sent now.

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [x] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
