### PR TITLE
Fix sm2 init failure.

### DIFF
--- a/crypto/evp/ec_ctrl.c
+++ b/crypto/evp/ec_ctrl.c
@@ -283,7 +283,8 @@ int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **pukm)
  */
 int EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid)
 {
-    return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_EC, EVP_PKEY_OP_TYPE_GEN,
+    int keytype = nid == EVP_PKEY_SM2 ? EVP_PKEY_SM2 : EVP_PKEY_EC;
+    return EVP_PKEY_CTX_ctrl(ctx, keytype, EVP_PKEY_OP_TYPE_GEN,
                              EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID,
                              nid, NULL);
 }


### PR DESCRIPTION
For sm2, keytype was missed. After adding keytype argument in EVP_PKEY_CTX_set_ec_paramgen_curve_nid API keytype is updating properly and working as expected.

Babassl ticket: https://github.com/Tongsuo-Project/Tongsuo/issues/589

