### PR TITLE
Fix coverity issues, CID 471315 and 356192

### DIFF
--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -432,7 +432,7 @@ static int pkey_dh_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
     else if (dctx->kdf_type == EVP_PKEY_DH_KDF_X9_42) {
 
         unsigned char *Z = NULL;
-        size_t Zlen = 0;
+        int Zlen = 0;
         if (!dctx->kdf_outlen || !dctx->kdf_oid)
             return 0;
         if (key == NULL) {

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -795,8 +795,10 @@ EC_POINTS *EC_POINTS_new(const EC_GROUP *group, int count)
 
     for (i = 0; i < count; i++) {
         point = EC_POINT_new(group);
-        if (point == NULL)
+        if (point == NULL) {
             EC_POINTS_free(ret);
+            return NULL;
+        }
 
         ret->items[i] = point;
     }


### PR DESCRIPTION
471315, EC_POINTS_new: Reads target of a freed pointer

356192, pkey_dh_derive: Out-of-bounds access to a buffer

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
