### PR TITLE
Define OPENSSL_NO_<algo> for alrorithms which has been removed

### DIFF
--- a/Configure
+++ b/Configure
@@ -588,8 +588,23 @@ our %disabled = ( # "what"         => "comment"
                   "zkp-gadget"          => "default",
                   "zkp-transcript"      => "default",
                   "bn-method"           => "default",
-                  "smtc"                 => "default",
-                  "smtc-debug"           => "default",
+                  "smtc"                => "default",
+                  "smtc-debug"          => "default",
+                  "aria"                => "default", # ARIA has been removed
+                  "bf"                  => "default", # Blowfish has been removed
+                  "blake2"              => "default", # Blake2 has been removed
+                  "camellia"            => "default", # Camellia has been removed
+                  "cast"                => "default", # CAST has been removed
+                  "idea"                => "default", # IDEA has been removed
+                  "md2"                 => "default", # MD2 has been removed
+                  "mdc2"                => "default", # MDC2 has been removed
+                  "md4"                 => "default", # MD4 has been removed
+                  "gost"                => "default", # GOST has been removed
+                  "rc2"                 => "default", # RC2 has been removed
+                  "rmd160"              => "default", # RIPEMD has been removed
+                  "ripemd"              => "default", # RIPEMD has been removed
+                  "seed"                => "default", # SEED has been removed
+                  "whirlpool"           => "default", # Whirlpool has been removed
                 );
 
 # Note: => pair form used for aesthetics, not to truly make a hash table


### PR DESCRIPTION
Fixes #638

To keep backward compatibility, still define the macro OPENSSL_NO_<algo> for the algorithm which has been removed by Tongsuo to solve compilation problems.

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
