### PR TITLE
Fix memory leak in TSAPI_ImportSM2Key()

### DIFF
--- a/crypto/tsapi/tsapi_lib.c
+++ b/crypto/tsapi/tsapi_lib.c
@@ -430,6 +430,8 @@ int TSAPI_ImportSM2Key(int index, int sign, const char *user,
 
     ok = 1;
 end:
+    OPENSSL_free(privkey);
+    OPENSSL_free(pubkey);
     TSAPI_SDF_CloseSession(hSessionHandle);
     TSAPI_SDF_CloseDevice(hDeviceHandle);
 #endif


### PR DESCRIPTION
privkey and pubkey should be freed at the end of TSAPI_ImportSM2Key().

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
