### PR TITLE
Export SM4 internal API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: config
-        run: ./config --strict-warnings enable-asan enable-ubsan enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-ntls enable-delegated-credential enable-cert-compression && perl configdata.pm --dump
+        run: ./config --strict-warnings enable-asan enable-ubsan enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-ntls enable-delegated-credential enable-cert-compression enable-export-sm4 && perl configdata.pm --dump
       - name: make
         run: make -s -j4
       - name: make test

--- a/Configure
+++ b/Configure
@@ -367,6 +367,7 @@ my @disablables = (
     "crypto-mdebug",
     "crypto-mdebug-backtrace",
     "ct",
+    "export-sm4",
     "ntls",
     "compatible-gm-ver",
     "deprecated",
@@ -509,6 +510,7 @@ our %disabled = ( # "what"         => "comment"
                   "dycert-ocsp"         => "default",
                   "delegated-credential" => "default",
                   "cert-compression"    => "default",
+                  "export-sm4"          => "default",
                 );
 
 # Note: => pair form used for aesthetics, not to truly make a hash table

--- a/include/crypto/sm4.h
+++ b/include/crypto/sm4.h
@@ -19,11 +19,15 @@
 #  error SM4 is disabled.
 # endif
 
-# define SM4_ENCRYPT     1
-# define SM4_DECRYPT     0
+# ifndef OPENSSL_NO_EXPORT_SM4
+#  include <openssl/sm4.h>
+# else
 
-# define SM4_BLOCK_SIZE    16
-# define SM4_KEY_SCHEDULE  32
+#  define SM4_ENCRYPT     1
+#  define SM4_DECRYPT     0
+
+#  define SM4_BLOCK_SIZE    16
+#  define SM4_KEY_SCHEDULE  32
 
 typedef struct SM4_KEY_st {
     uint32_t rk[SM4_KEY_SCHEDULE];
@@ -32,6 +36,9 @@ typedef struct SM4_KEY_st {
 int SM4_set_key(const uint8_t *key, SM4_KEY *ks);
 
 void SM4_encrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
+
+void SM4_decrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
+# endif
 
 /*
  * Use sm4 affine transformation to aes-ni
@@ -63,8 +70,6 @@ void SM4_encrypt_affine_ni(const uint8_t *in, uint8_t *out,
 #   endif
 #  endif
 # endif
-
-void SM4_decrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
 
 void sm4_ctr128_encrypt_blocks (const unsigned char *in, unsigned char *out,size_t blocks, const void *key,
                                 const unsigned char ivec[16]);

--- a/include/openssl/sm4.h
+++ b/include/openssl/sm4.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef HEADER_SM4_H
+# define HEADER_SM4_H
+
+# if !defined(OPENSSL_NO_SM4) && !defined(OPENSSL_NO_EXPORT_SM4)
+#  include <openssl/e_os2.h>
+#  include <stddef.h>
+
+#  ifdef  __cplusplus
+extern "C" {
+#  endif
+
+# define SM4_ENCRYPT     1
+# define SM4_DECRYPT     0
+
+# define SM4_BLOCK_SIZE    16
+# define SM4_KEY_SCHEDULE  32
+
+typedef struct SM4_KEY_st {
+    uint32_t rk[SM4_KEY_SCHEDULE];
+} SM4_KEY;
+
+int SM4_set_key(const uint8_t *key, SM4_KEY *ks);
+
+void SM4_encrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
+void SM4_decrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
+
+#  ifdef  __cplusplus
+}
+#  endif
+# endif
+
+#endif

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4668,3 +4668,6 @@ SM3_Init                                6614	1_1_1h	EXIST::FUNCTION:SM3
 SM3_Update                              6615	1_1_1h	EXIST::FUNCTION:SM3
 SM3_Final                               6616	1_1_1h	EXIST::FUNCTION:SM3
 SM3_Transform                           6617	1_1_1h	EXIST::FUNCTION:SM3
+SM4_encrypt                             6618	1_1_1h	EXIST::FUNCTION:EXPORT_SM4,SM4
+SM4_decrypt                             6619	1_1_1h	EXIST::FUNCTION:EXPORT_SM4,SM4
+SM4_set_key                             6620	1_1_1h	EXIST::FUNCTION:EXPORT_SM4,SM4


### PR DESCRIPTION
SM4 internal API may be needed by applications or Tongsuo SDK, such as tongsuo-go-sdk.

If you want to export SM4 internal API, add enable-export-sm4 to config options.

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
