### PR TITLE
Define SMTC_MODULE for liblegacy.a to avoid multiple definition

### DIFF
--- a/providers/build.info
+++ b/providers/build.info
@@ -144,6 +144,10 @@ IF[{- !$disabled{smtc} -}]
   DEFINE[$LIBDEFAULT]=SMTC_MODULE
   DEFINE[../libssl]=SMTC_MODULE
 
+  IF[{- $disabled{module} -}]
+    DEFINE[$LIBLEGACY]=SMTC_MODULE
+  ENDIF
+
 {- use File::Spec::Functions;
   our $ex_lib = $withargs{atf_slibce_lib} &&
     (file_name_is_absolute($withargs{atf_slibce_lib}) ?


### PR DESCRIPTION
Fix compilation failure issue found in coverity CI. Multiple definition of ossl_set_error_state and ossl_prov_is_running when enable smtc, legacy and module, so SMTC shoud be defined for liblegacy.a.

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
