### PR TITLE
Fix CVE-2024-13176 on 8.3 branch

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@
 
  Changes between 8.3.3 and 8.3.4 [xxxx年xx月xx日]
 
+  *) 修复CVE-2024-13176
+
   *) 重新修复CVE-2022-4304
 
   *) 修复CVE-2024-9143

--- a/CHANGES.en
+++ b/CHANGES.en
@@ -7,6 +7,8 @@
 
  Changes between 8.3.3 and 8.3.4 [xx XXX xxxx]
 
+  *) Fix CVE-2024-13176 
+
   *) Alternative fix for CVE-2022-4304
 
   *) Fix CVE-2024-9143

--- a/crypto/bn/bn_err.c
+++ b/crypto/bn/bn_err.c
@@ -51,7 +51,7 @@ static const ERR_STRING_DATA BN_str_functs[] = {
     {ERR_PACK(ERR_LIB_BN, BN_F_BN_LSHIFT, 0), "BN_lshift"},
     {ERR_PACK(ERR_LIB_BN, BN_F_BN_MOD_EXP2_MONT, 0), "BN_mod_exp2_mont"},
     {ERR_PACK(ERR_LIB_BN, BN_F_BN_MOD_EXP_MONT, 0), "BN_mod_exp_mont"},
-    {ERR_PACK(ERR_LIB_BN, BN_F_BN_MOD_EXP_MONT_CONSTTIME, 0),
+    {ERR_PACK(ERR_LIB_BN, BN_F_BN_MOD_EXP_MONT_FIXED_TOP, 0),
      "BN_mod_exp_mont_consttime"},
     {ERR_PACK(ERR_LIB_BN, BN_F_BN_MOD_EXP_MONT_WORD, 0),
      "BN_mod_exp_mont_word"},

--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -590,7 +590,7 @@ static int MOD_EXP_CTIME_COPY_FROM_PREBUF(BIGNUM *b, int top,
  * out by Colin Percival,
  * http://www.daemonology.net/hyperthreading-considered-harmful/)
  */
-int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
                               const BIGNUM *m, BN_CTX *ctx,
                               BN_MONT_CTX *in_mont)
 {
@@ -607,12 +607,8 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
     unsigned int t4 = 0;
 #endif
 
-    bn_check_top(a);
-    bn_check_top(p);
-    bn_check_top(m);
-
     if (!BN_is_odd(m)) {
-        BNerr(BN_F_BN_MOD_EXP_MONT_CONSTTIME, BN_R_CALLED_WITH_EVEN_MODULUS);
+        BNerr(BN_F_BN_MOD_EXP_MONT_FIXED_TOP, BN_R_CALLED_WITH_EVEN_MODULUS);
         return 0;
     }
 
@@ -1113,7 +1109,7 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
             goto err;
     } else
 #endif
-    if (!BN_from_montgomery(rr, &tmp, mont, ctx))
+    if (!bn_from_mont_fixed_top(rr, &tmp, mont, ctx))
         goto err;
     ret = 1;
  err:
@@ -1125,6 +1121,19 @@ int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
     }
     BN_CTX_end(ctx);
     return ret;
+}
+
+int BN_mod_exp_mont_consttime(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+                              const BIGNUM *m, BN_CTX *ctx,
+                              BN_MONT_CTX *in_mont)
+{
+    bn_check_top(a);
+    bn_check_top(p);
+    bn_check_top(m);
+    if (!bn_mod_exp_mont_fixed_top(rr, a, p, m, ctx, in_mont))
+        return 0;
+    bn_correct_top(rr);
+    return 1;
 }
 
 int BN_mod_exp_mont_word(BIGNUM *rr, BN_ULONG a, const BIGNUM *p,

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -12,6 +12,7 @@
 
 #include <openssl/err.h>
 #include <openssl/opensslv.h>
+#include "crypto/bn.h"
 
 #include "ec_local.h"
 
@@ -1155,10 +1156,10 @@ static int ec_field_inverse_mod_ord(const EC_GROUP *group, BIGNUM *r,
     if (!BN_sub(e, group->order, e))
         goto err;
     /*-
-     * Exponent e is public.
-     * No need for scatter-gather or BN_FLG_CONSTTIME.
+     * Although the exponent is public we want the result to be
+     * fixed top.
      */
-    if (!BN_mod_exp_mont(r, x, e, group->order, ctx, group->mont_data))
+    if (!bn_mod_exp_mont_fixed_top(r, x, e, group->order, ctx, group->mont_data))
         goto err;
 
     ret = 1;

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -215,7 +215,7 @@ BN_F_BN_GF2M_MOD_SQRT:137:BN_GF2m_mod_sqrt
 BN_F_BN_LSHIFT:145:BN_lshift
 BN_F_BN_MOD_EXP2_MONT:118:BN_mod_exp2_mont
 BN_F_BN_MOD_EXP_MONT:109:BN_mod_exp_mont
-BN_F_BN_MOD_EXP_MONT_CONSTTIME:124:BN_mod_exp_mont_consttime
+BN_F_BN_MOD_EXP_MONT_FIXED_TOP:124:bn_mod_exp_mont_fixed_top
 BN_F_BN_MOD_EXP_MONT_WORD:117:BN_mod_exp_mont_word
 BN_F_BN_MOD_EXP_RECP:125:BN_mod_exp_recp
 BN_F_BN_MOD_EXP_SIMPLE:126:BN_mod_exp_simple

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -72,6 +72,9 @@ int bn_set_words(BIGNUM *a, const BN_ULONG *words, int num_words);
  */
 int bn_mul_mont_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
                           BN_MONT_CTX *mont, BN_CTX *ctx);
+int bn_mod_exp_mont_fixed_top(BIGNUM *rr, const BIGNUM *a, const BIGNUM *p,
+                              const BIGNUM *m, BN_CTX *ctx,
+                              BN_MONT_CTX *in_mont);
 int bn_to_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,
                          BN_CTX *ctx);
 int bn_from_mont_fixed_top(BIGNUM *r, const BIGNUM *a, BN_MONT_CTX *mont,

--- a/include/openssl/bnerr.h
+++ b/include/openssl/bnerr.h
@@ -51,7 +51,7 @@ int ERR_load_BN_strings(void);
 # define BN_F_BN_LSHIFT                                   145
 # define BN_F_BN_MOD_EXP2_MONT                            118
 # define BN_F_BN_MOD_EXP_MONT                             109
-# define BN_F_BN_MOD_EXP_MONT_CONSTTIME                   124
+# define BN_F_BN_MOD_EXP_MONT_FIXED_TOP                   124
 # define BN_F_BN_MOD_EXP_MONT_WORD                        117
 # define BN_F_BN_MOD_EXP_RECP                             125
 # define BN_F_BN_MOD_EXP_SIMPLE                           126


### PR DESCRIPTION
Fixed timing side-channel in ECDSA signature computation.

There is a timing signal of around 300 nanoseconds when the top word of
the inverted ECDSA nonce value is zero. This can happen with significant
probability only for some of the supported elliptic curves. In particular
the NIST P-521 curve is affected. To be able to measure this leak, the
attacker process must either be located in the same physical computer or
must have a very fast network connection with low latency.

([CVE-2024-13176])


##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
