### PR TITLE
Fix for SM4-CBC failure

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3547,7 +3547,7 @@ int speed_main(int argc, char **argv)
                     EVP_CIPHER_CTX_rand_key(loopargs[k].ctx, loopargs[k].key);
 		    if (!ae_mode) {
                         if (!EVP_CipherInit_ex(loopargs[k].ctx, NULL, NULL,
-                                               loopargs[k].key, NULL, -1)) {
+                                               loopargs[k].key, iv, -1)) {
                             BIO_printf(bio_err, "\nFailed to set the key\n");
                             dofail();
                             exit(1);


### PR DESCRIPTION
Description:
This PR addresses a failure observed in SM4-CBC mode during openssl speed tests with qatprovider

Root Cause:
The issue was due to passing IV as NULL from BabaSSL corrected as per OpenSSL.

Fix:
The corresponding fix from the OpenSSL master branch has been identified and ported to the BabaSSL master branch to align with the latest behavior and resolve the failure.

Babassl ticket: https://github.com/Tongsuo-Project/Tongsuo/issues/487