### PR TITLE
Upgrade runner to ubuntu-22.04 in compiler-zoo.yml

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -16,17 +16,11 @@ jobs:
       matrix:
         zoo: [
           {
-            cc: gcc-7,
-            distro: ubuntu-20.04
-          }, {
-            cc: gcc-8,
-            distro: ubuntu-20.04
-          }, {
             cc: gcc-9,
-            distro: ubuntu-20.04
+            distro: ubuntu-22.04
           }, {
             cc: gcc-10,
-            distro: ubuntu-20.04
+            distro: ubuntu-22.04
           }, {
             cc: gcc-11,
             distro: ubuntu-22.04
@@ -34,26 +28,11 @@ jobs:
             cc: gcc-12,
             distro: ubuntu-22.04
           }, {
-            cc: clang-6.0,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-7,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-8,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-9,
-            distro: ubuntu-20.04
-          }, {
-            cc: clang-10,
-            distro: ubuntu-20.04
-          }, {
             cc: clang-11,
-            distro: ubuntu-20.04
+            distro: ubuntu-22.04
           }, {
             cc: clang-12,
-            distro: ubuntu-20.04
+            distro: ubuntu-22.04
           }, {
             cc: clang-13,
             distro: ubuntu-22.04


### PR DESCRIPTION
Ubuntu 20.04 LTS runner has be removed on 2025-04-15.

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
