### PR TITLE
Change fuzzy-checker CI OS version from "ubuntu-latest" to "ubuntu-22.04" so as to avoid errors.

### DIFF
--- a/.github/workflows/fuzz-checker.yml
+++ b/.github/workflows/fuzz-checker.yml
@@ -39,7 +39,7 @@ jobs:
             tests: -test_memleak
           }
         ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: install packages
       run: |

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -28,7 +28,7 @@ jobs:
           enable-zlib,
           enable-ntls,
         ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Adjust ASLR for sanitizer
       run: |


### PR DESCRIPTION
Current fuzzy-checker CI always fails as the incorrect environment configuration raised by OS version.
Changing the OS version from "ubuntu-latest" to "ubuntu-22.04" fixes this error.
