### PR TITLE
Fix CI bugs and make them more efficient.

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -26,8 +26,7 @@ jobs:
         CC=gcc ./config --banner=Configured --debug --coverage no-asm enable-rc5 enable-ssl3 enable-nextprotoneg \
             enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-ec_sm2p_64_gcc_128 \
             no-shared enable-buildtest-c++ enable-external-tests -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION \
-            enable-ntls enable-cert-compression enable-delegated-credential enable-status enable-ec_elgamal \
-            enable-paillier enable-sm2_threshold
+            enable-ntls enable-cert-compression enable-delegated-credential enable-status enable-sm2_threshold
 
     - name: config dump
       run: ./configdata.pm --dump
@@ -36,7 +35,7 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
     - name: generate coverage info
-      run: lcov -d . -c -o ./lcov.info
+      run: lcov --ignore-errors mismatch -d . -c -o ./lcov.info
     - name: Coveralls upload
       uses: coverallsapp/github-action@v1.1.2
       with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
         platform:
           - arch: win64
@@ -56,7 +55,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
     runs-on: ${{matrix.os}}
     steps:
@@ -80,7 +78,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
1. Remove windows 2019 support: Github CI has stopped support for windows 2019. 
2. Remove homomorphic encryption (ec-elgamal, paillier) coverage tests. They cost hours for each CI, and are seldom used.
3. Add ignore errors when generating coverage info. It does not recognize Macros and treats them as errors.

Changes have been tested on forked branches:  https://github.com/vincehong/Tongsuo/actions/runs/16020066122