### PR TITLE
Fix issue/740: Use temporary variable to resolve type conversion error.

### DIFF
--- a/ssl/statem_ntls/ntls_statem_clnt.c
+++ b/ssl/statem_ntls/ntls_statem_clnt.c
@@ -2035,7 +2035,6 @@ int tls_construct_client_key_exchange_ntls(SSL *s, WPACKET *pkt)
         SSLfatal_ntls(s, SSL_AD_HANDSHAKE_FAILURE, ERR_R_INTERNAL_ERROR);
         goto err;
     }
-
     return 1;
 err:
     OPENSSL_clear_free(s->s3.tmp.pms, s->s3.tmp.pmslen);


### PR DESCRIPTION
Fix issue 740 with a temporary variable.
MIPS64 cross compiler does not handle the case of converting unsigned char * pointer to size_t * pointer properly, which leads to memory overflow.
So we have to use a temporary variable to convert types explicitly in order to fix this test.