### PR TITLE
Add bn_mul_mont LoongArch asm support

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -519,6 +519,7 @@ my %targets = (
     # specifications,
     "linux64-loongarch64" => {
         inherit_from     => [ "linux-generic64"],
+        asm_arch         => 'loongarch64',
         perlasm_scheme   => "linux64",
     },
 

--- a/crypto/bn/asm/loongarch-mont.pl
+++ b/crypto/bn/asm/loongarch-mont.pl
@@ -1,0 +1,577 @@
+#! /usr/bin/env perl
+# Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+######################################################################
+# Here is register layout for LOONGARCH ABIs.
+# The return value is placed in $v0($a0).
+
+($zero,$ra,$tp,$sp,$fp)=map("\$r$_",(0..3,22));
+($a0,$a1,$a2,$a3,$a4,$a5,$a6,$a7)=map("\$r$_",(4..11));
+($t0,$t1,$t2,$t3,$t4,$t5,$t6,$t7,$t8)=map("\$r$_",(12..20));
+($s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7,$s8)=map("\$r$_",(23..31));
+
+
+$PTR_ADD="addi.d";
+$REG_S="st.d";
+$REG_L="ld.d";
+$SZREG=8;
+
+######################################################################
+
+while (($output=shift) && ($output!~/\w[\w\-]*\.\w+$/)) {}
+open STDOUT,">$output";
+
+$LD="ld.d";
+$ST="st.d";
+$MULD="mul.d";
+$MULHD="mulh.du";
+$ADDU="add.d";
+$SUBU="sub.d";
+$BNSZ=8;
+$LDX="ldx.d";
+
+# int bn_mul_mont(
+$rp=$a0;	# BN_ULONG *rp,
+$ap=$a1;	# const BN_ULONG *ap,
+$bp=$a2;	# const BN_ULONG *bp,
+$np=$a3;	# const BN_ULONG *np,
+$n0=$a4;	# const BN_ULONG *n0,
+$num=$a5;	# int num);
+
+$lo0=$a6;
+$hi0=$a7;
+$lo1=$t1;
+$hi1=$t2;
+$aj=$t3;
+$bi=$t4;
+$nj=$t5;
+$tp=$t6;
+$alo=$t7;
+$ahi=$s0;
+$nlo=$s1;
+$nhi=$s2;
+$tj=$s3;
+$i=$s4;
+$j=$s5;
+$m1=$s6;
+
+$code=<<___;
+.text
+.align  5
+.globl	bn_mul_mont
+bn_mul_mont:
+___
+$code.=<<___;
+	slti	$t8,$num,4
+	bnez	$t8,1f
+	slti	$t8,$num,17
+	bnez	$t8,bn_mul_mont_internal
+1:	li.d	$a0,0
+	jr	$ra
+
+.align	5
+bn_mul_mont_internal:
+	addi.d	$t8,$num,-4
+	beqz	$t8,__bn256_mul_mont
+	addi.d	$sp,$sp,-64
+	$REG_S	$fp,$sp,$SZREG*0
+	$REG_S	$s0,$sp,$SZREG*1
+	$REG_S	$s1,$sp,$SZREG*2
+	$REG_S	$s2,$sp,$SZREG*3
+	$REG_S	$s3,$sp,$SZREG*4
+	$REG_S	$s4,$sp,$SZREG*5
+	$REG_S	$s5,$sp,$SZREG*6
+	$REG_S	$s6,$sp,$SZREG*7
+___
+$code.=<<___;
+	move	$fp,$sp
+	$LD	$n0,$n0,0
+	$LD	$bi,$bp,0	# bp[0]
+	$LD	$aj,$ap,0	# ap[0]
+	$LD	$nj,$np,0	# np[0]
+
+	$PTR_ADD	$sp,$sp,-2*$BNSZ	# place for two extra words
+	slli.d	$num,$num,`log($BNSZ)/log(2)`
+	li.d	$t8,-4096
+	$SUBU	$sp,$sp,$num
+	and	$sp,$sp,$t8
+
+	$LD	$ahi,$ap,$BNSZ
+	$LD	$nhi,$np,$BNSZ
+	$MULD	$lo0,$aj,$bi
+	$MULHD	$hi0,$aj,$bi
+	$MULD	$m1,$lo0,$n0
+
+	$MULD	$alo,$ahi,$bi
+	$MULHD	$ahi,$ahi,$bi
+
+	$MULD	$lo1,$nj,$m1
+	$MULHD	$hi1,$nj,$m1
+	$ADDU	$lo1,$lo1,$lo0
+	sltu	$t8,$lo1,$lo0
+	$ADDU	$hi1,$hi1,$t8
+	$MULD	$nlo,$nhi,$m1
+	$MULHD	$nhi,$nhi,$m1
+
+	move	$tp,$sp
+	li.d	$j,2*$BNSZ
+.align	4
+.L1st:
+	$ADDU	$aj,$ap,$j
+	$ADDU	$nj,$np,$j
+	$LD	$aj,$aj,0
+	$LD	$nj,$nj,0
+
+	$ADDU	$lo0,$alo,$hi0
+	$ADDU	$lo1,$nlo,$hi1
+	sltu	$t8,$lo0,$hi0
+	sltu	$t0,$lo1,$hi1
+	$ADDU	$hi0,$ahi,$t8
+	$ADDU	$hi1,$nhi,$t0
+	$MULD	$alo,$aj,$bi
+	$MULHD	$ahi,$aj,$bi
+
+	$ADDU	$lo1,$lo1,$lo0
+	sltu	$t8,$lo1,$lo0
+	$ADDU	$hi1,$hi1,$t8
+	addi.d	$j,$j,$BNSZ
+	$ST	$lo1,$tp,0
+	sltu	$t0,$j,$num
+	$MULD	$nlo,$nj,$m1
+	$MULHD	$nhi,$nj,$m1
+
+	$PTR_ADD	$tp,$tp,$BNSZ
+	bnez	$t0,.L1st
+
+	$ADDU	$lo0,$alo,$hi0
+	sltu	$t8,$lo0,$hi0
+	$ADDU	$hi0,$ahi,$t8
+
+	$ADDU	$lo1,$nlo,$hi1
+	sltu	$t0,$lo1,$hi1
+	$ADDU	$hi1,$nhi,$t0
+	$ADDU	$lo1,$lo1,$lo0
+	sltu	$t8,$lo1,$lo0
+	$ADDU	$hi1,$hi1,$t8
+
+	$ST	$lo1,$tp,0
+
+	$ADDU	$hi1,$hi1,$hi0
+	sltu	$t8,$hi1,$hi0
+	$ST	$hi1,$tp,$BNSZ
+	$ST	$t8,$tp,2*$BNSZ
+
+	li.d	$i,$BNSZ
+.align	4
+.Louter:
+	$ADDU	$bi,$bp,$i
+	$LD	$bi,$bi,0
+	$LD	$aj,$ap,0
+	$LD	$ahi,$ap,$BNSZ
+	$LD	$tj,$sp,0
+
+	$LD	$nj,$np,0
+	$LD	$nhi,$np,$BNSZ
+	$MULD	$lo0,$aj,$bi
+	$MULHD	$hi0,$aj,$bi
+	$ADDU	$lo0,$lo0,$tj
+	sltu	$t8,$lo0,$tj
+	$ADDU	$hi0,$hi0,$t8
+	$MULD	$m1,$lo0,$n0
+
+	$MULD	$alo,$ahi,$bi
+	$MULHD	$ahi,$ahi,$bi
+
+	$MULD	$lo1,$nj,$m1
+	$MULHD	$hi1,$nj,$m1
+
+	$ADDU	$lo1,$lo1,$lo0
+	sltu	$t8,$lo1,$lo0
+	$ADDU	$hi1,$hi1,$t8
+	$MULD	$nlo,$nhi,$m1
+	$MULHD	$nhi,$nhi,$m1
+
+	move	$tp,$sp
+	li.d	$j,2*$BNSZ
+	$LD	$tj,$tp,$BNSZ
+.align	4
+.Linner:
+	$ADDU	$aj,$ap,$j
+	$ADDU	$nj,$np,$j
+	$LD	$aj,$aj,0
+	$LD	$nj,$nj,0
+
+	$ADDU	$lo0,$alo,$hi0
+	$ADDU	$lo1,$nlo,$hi1
+	sltu	$t8,$lo0,$hi0
+	sltu	$t0,$lo1,$hi1
+	$ADDU	$hi0,$ahi,$t8
+	$ADDU	$hi1,$nhi,$t0
+	$MULD	$alo,$aj,$bi
+	$MULHD	$ahi,$aj,$bi
+
+	$ADDU	$lo0,$lo0,$tj
+	addi.d	$j,$j,$BNSZ
+	sltu	$t8,$lo0,$tj
+	$ADDU	$lo1,$lo1,$lo0
+	$ADDU	$hi0,$hi0,$t8
+	sltu	$t0,$lo1,$lo0
+	$LD	$tj,$tp,2*$BNSZ
+	$ADDU	$hi1,$hi1,$t0
+	sltu	$t8,$j,$num
+	$MULD	$nlo,$nj,$m1
+	$MULHD	$nhi,$nj,$m1
+	$ST	$lo1,$tp,0
+	$PTR_ADD	$tp,$tp,$BNSZ
+	bnez	$t8,.Linner
+
+	$ADDU	$lo0,$alo,$hi0
+	sltu	$t8,$lo0,$hi0
+	$ADDU	$hi0,$ahi,$t8
+	$ADDU	$lo0,$lo0,$tj
+	sltu	$t0,$lo0,$tj
+	$ADDU	$hi0,$hi0,$t0
+
+	$LD	$tj,$tp,2*$BNSZ
+	$ADDU	$lo1,$nlo,$hi1
+	sltu	$t8,$lo1,$hi1
+	$ADDU	$hi1,$nhi,$t8
+	$ADDU	$lo1,$lo1,$lo0
+	sltu	$t0,$lo1,$lo0
+	$ADDU	$hi1,$hi1,$t0
+	$ST	$lo1,$tp,0
+
+	$ADDU	$lo1,$hi1,$hi0
+	sltu	$hi1,$lo1,$hi0
+	$ADDU	$lo1,$lo1,$tj
+	sltu	$t8,$lo1,$tj
+	$ADDU	$hi1,$hi1,$t8
+	$ST	$lo1,$tp,$BNSZ
+	$ST	$hi1,$tp,2*$BNSZ
+
+	$PTR_ADD	$i,$i,$BNSZ
+	sltu	$t0,$i,$num
+	bnez	$t0,.Louter
+
+	$ADDU	$tj,$sp,$num	# &tp[num]
+	move	$tp,$sp
+	move	$ap,$sp
+	li.d	$hi0,0	# clear borrow bit
+
+.align	4
+.Lsub:
+	$LD	$lo0,$tp,0
+	$LD	$lo1,$np,0
+	$PTR_ADD	$tp,$tp,$BNSZ
+	$PTR_ADD	$np,$np,$BNSZ
+	$SUBU	$lo1,$lo0,$lo1	# tp[i]-np[i]
+	sltu	$t8,$lo0,$lo1
+	$SUBU	$lo0,$lo1,$hi0
+	sltu	$hi0,$lo1,$lo0
+	$ST	$lo0,$rp,0
+	or	$hi0,$hi0,$t8
+	sltu	$t8,$tp,$tj
+	$PTR_ADD	$rp,$rp,$BNSZ
+	bnez	$t8,.Lsub
+	$SUBU	$hi0,$hi1,$hi0	# handle upmost overflow bit
+	move	$tp,$sp
+	$SUBU	$rp,$rp,$num	# restore rp
+	nor	$hi1,$hi0,$zero
+.Lcopy:
+	$LD	$nj,$tp,0	# conditional move
+	$LD	$aj,$rp,0
+	$ST	$zero,$tp,0
+	$PTR_ADD	$tp,$tp,$BNSZ
+	and	$nj,$nj,$hi0
+	and	$aj,$aj,$hi1
+	or	$aj,$aj,$nj
+	sltu	$t8,$tp,$tj
+	$ST	$aj,$rp,0
+	$PTR_ADD	$rp,$rp,$BNSZ
+	bnez	$t8,.Lcopy
+	li.d	$a0,1
+	li.d	$t0,1
+	move	$sp,$fp
+___
+$code.=<<___;
+	$REG_L	$fp,$sp,$SZREG*0
+	$REG_L	$s0,$sp,$SZREG*1
+	$REG_L	$s1,$sp,$SZREG*2
+	$REG_L	$s2,$sp,$SZREG*3
+	$REG_L	$s3,$sp,$SZREG*4
+	$REG_L	$s4,$sp,$SZREG*5
+	$REG_L	$s5,$sp,$SZREG*6
+	$REG_L	$s6,$sp,$SZREG*7
+	$PTR_ADD	$sp,$sp,64;
+	jr	$ra
+___
+
+$zero="\$r0";	#zero
+$ra="\$r1";	#ra
+$tp="\$r2";	#tp
+$sp="\$r3";	#sp
+$rp="\$r4";	#a0
+
+$ap="\$r5";	#a1
+$t0="\$r5";
+
+$bp="\$r6";	#a2
+
+$np="\$r7";	#a3
+$t1="\$r7";
+
+$n0="\$r8";	#a4
+
+$num="\$r9";	#a5
+$bp_end="\$r9";
+
+$bi="\$r10";	#a6
+$mi="\$r10";	#a6
+
+$t2="\$r11";	#a7
+
+$d0="\$r12";	#t0
+$d1="\$r13";	#t1
+$d2="\$r14";	#t2
+$d3="\$r15";	#t3
+$m0="\$r16";	#t4;
+$m1="\$r17";	#t5;
+$m2="\$r18";	#t6
+$m3="\$r19";	#t7;
+$carry="\$r20";	#t8;
+#r21; platform-reserved
+
+$fp="\$r22";	#s9/fp
+
+
+$acc0="\$r23";	#s0;
+$acc1="\$r24";	#s1;
+$acc2="\$r25";	#s2;
+$acc3="\$r26";	#s3;
+
+$t4="\$r27";	#s4;
+$t5="\$r28";	#s5;
+$t6="\$r29";	#s6;
+$t7="\$r30";	#s7;
+$t3="\$r31";    #s8
+
+$code.=<<___;
+.type __bn256_mul_mont,%function
+
+__bn256_mul_mont:
+.align 4
+	$PTR_ADD	$sp,$sp,-160
+	alsl.d	$bp_end,$num,$bp,3
+	$LD	$n0,$n0,0
+	$LD	$bi,$bp,8*0
+
+	$LD	$d0,$ap,8*0
+	$LD	$d1,$ap,8*1
+	$REG_S	$s8,$sp,144
+	move	$carry,$zero
+
+	$LD	$d2,$ap,8*2
+	$LD	$d3,$ap,8*3
+	//$PTR_ADD	$fp,$sp,160
+
+	$LD	$m0,$np,8*0
+	$LD	$m1,$np,8*1
+	$REG_S	$s0,$sp,136
+	$REG_S	$s1,$sp,128
+
+
+	move	$acc0, $zero
+	move	$acc1, $zero
+	$LD	$m2,$np,8*2
+	$LD	$m3,$np,8*3
+
+	$REG_S	$s2,$sp,120
+	$REG_S	$s3,$sp,112
+	move	$acc2, $zero
+	move	$acc3, $zero
+
+	$REG_S	$s4,$sp,104
+	$REG_S	$s5,$sp,96
+	$REG_S	$s6,$sp,88
+	$REG_S	$s7,$sp,80
+
+.Loop_mul4x_1st_reduction:
+	$MULD	$t0,$d0,$bi		//@4
+	$MULD	$t1,$d1,$bi
+	$MULD	$t2,$d2,$bi
+	$MULD	$t3,$d3,$bi
+
+	$MULHD	$t4,$d0,$bi
+	$MULHD	$t5,$d1,$bi
+	$ADDU	$acc0,$acc0,$t0		//0 adds	$acc0,$acc0,LO($d0*$bi)
+	$ADDU	$acc1,$acc1,$t1		//1 adcs	$acc1,$acc1,LO($d1*$bi)
+
+	$PTR_ADD	$bp,$bp,8
+	$MULD	$t6,$n0,$acc0		//$mi alias with $t6
+	sltu	$t0,$acc0,$t0		//done 0
+	sltu	$t1,$acc1,$t1
+
+	$ADDU	$acc1,$acc1,$t0
+	sltu	$t7,$zero,$acc0		//10 subs	$zero,$acc0,1
+	$ADDU	$acc2,$acc2,$t2		//2 adcs	$acc2,$acc2,LO($d2*$bi)
+	$ADDU	$acc3,$acc3,$t3		//3 adcs	$acc3,$acc3,LO($d3*$bi)
+
+
+	sltu	$t0,$acc1,$t0
+	$ADDU	$acc1,$acc1,$t4		//11 adds	$acc1,$acc1,HI($d0*$bi)
+	sltu	$t2,$acc2,$t2
+	sltu	$t3,$acc3,$t3
+
+	or	$t0,$t0,$t1		//done 1
+	sltu	$t4,$acc1,$t4		//done 11
+	$ADDU	$acc0,$acc1,$t7		//20 adcs	$acc0,$acc1,LO($m1*$mi)
+	$MULHD	$t1,$d2,$bi
+
+	$MULD	$t7,$m1,$t6
+	$ADDU	$t4,$t4,$t5
+	sltu	$acc1,$acc0,$acc1
+	$ADDU	$acc2,$acc2,$t0
+
+	$MULHD	$t5,$d3,$bi
+	$MULD	$bi,$m2,$t6
+	sltu	$t0,$acc2,$t0
+	$ADDU	$acc2,$acc2,$t4		//12 adcs	$acc2,$acc2,HI($d1*$bi)
+
+
+	or	$t0,$t0,$t2		//done 2
+	sltu	$t4,$acc2,$t4		//done 12
+	$MULD	$t2,$m3,$t6
+	$ADDU	$acc0,$acc0,$t7
+
+	$ADDU	$t4,$t4,$t1
+	$ADDU	$acc3,$acc3,$t0
+	sltu	$t7,$acc0,$t7
+	$MULHD	$t1,$m0,$t6
+
+	sltu	$t0,$acc3,$t0
+	$ADDU	$acc3,$acc3,$t4		//13 adcs	$acc3,$acc3,HI($d2*$bi)
+	or	$t7,$acc1,$t7		//done 20
+	$ADDU	$acc1,$acc2,$bi		//21 adcs	$acc1,$acc2,LO($m2*$mi)
+
+	or	$t0,$t0,$t3		//done 3,	adc $acc4,$zero,$zero
+	sltu	$t4,$acc3,$t4		//done 13
+	sltu	$acc2,$acc1,$acc2
+	$MULHD	$t3,$m1,$t6
+
+	$ADDU	$t4,$t4,$t5
+	$ADDU	$acc1,$acc1,$t7
+	$ADDU	$acc3,$acc3,$t2		//22 adcs	$acc2,$acc3,LO($m3*$mi)
+	$MULHD	$t5,$m2,$t6
+
+
+	$ADDU	$t0,$t0,$t4		//14 addc	$acc4,$acc4,HI($d3*$bi)
+	sltu	$t7,$acc1,$t7
+	sltu	$t2,$acc3,$t2
+	$ADDU	$acc0,$acc0,$t1		//30 adcs	$acc0,$acc0,HI($m0*$mi)
+
+	or	$t7,$acc2,$t7		//done 21
+	sltu	$t1,$acc0,$t1
+	$LD	$bi,$bp,0
+	$ADDU	$t0,$t0,$carry  	//23 adcs	$acc3,$acc4,$carry
+
+	$ADDU	$acc2,$acc3,$t7
+	$ADDU	$t1,$t3,$t1		//done 30
+	$MULHD	$t6,$m3,$t6
+	sltu	$carry,$t0,$carry
+
+
+	sltu	$t7,$acc2,$acc3
+	$ADDU	$acc1,$acc1,$t1		//31 adcs	$acc1,$acc1,HI($m1*$mi)
+
+	or	$t7,$t2,$t7		//done 22
+	sltu	$t1,$acc1,$t1		//done 31
+
+	$ADDU	$acc3,$t0,$t7
+	$ADDU	$t1,$t1,$t5
+
+	sltu	$t7,$acc3,$t7
+	$ADDU	$acc2,$acc2,$t1		//32 adcs	$acc2,$acc2,HI($m2*$mi)
+
+	or	$carry,$carry,$t7	//done 23, adc	$carry,$zero,$zero
+	sltu	$t1,$acc2,$t1		//done 32
+
+	$ADDU	$t1,$t1,$t6
+
+	$ADDU	$acc3,$acc3,$t1		//33 adcs	$acc3,$acc3,HI($m3*$mi)
+	sltu	$t1,$acc3,$t1		//done 33
+
+	$ADDU	$carry,$carry,$t1	//adc $carry,$carry,$zero
+
+	bne	$bp,$bp_end,.Loop_mul4x_1st_reduction
+
+	sltu	$n0,$acc0,$m0		//subs	$t0,$acc0,$m0
+	$SUBU	$t0,$acc0,$m0
+	sltu	$bp_end,$acc1,$m1	//sbcs	$t1,$acc1,$m1
+	$SUBU	$t1,$acc1,$m1
+
+	sltu	$m1,$t1,$n0
+	$SUBU	$t1,$t1,$n0
+	sltu	$bp,$acc2,$m2		//sbcs	$t2,$acc2,$m2
+	$SUBU	$t2,$acc2,$m2
+
+	or	$n0,$bp_end,$m1
+	sltu	$bp_end,$acc3,$m3	//sbcs	$t3,$acc3,$m3
+	$SUBU	$t3,$acc3,$m3
+
+	sltu	$m2,$t2,$n0
+	$SUBU	$t2,$t2,$n0
+	$REG_L	$s7,$sp,80
+	$REG_L	$s6,$sp,88
+
+	or	$n0,$bp,$m2
+	$REG_L	$s5,$sp,96
+	$REG_L	$s4,$sp,104
+
+	sltu	$m3,$t3,$n0
+	$SUBU	$t3,$t3,$n0
+
+	or	$n0,$bp_end,$m3
+
+	sltu	$n0,$carry,$n0		//sbcs	$zero,$carry,$zero
+
+	maskeqz	$m3,$acc3,$n0
+	masknez	$d3,$t3,$n0
+	$REG_L	$s8,$sp,144
+	$REG_L	$s3,$sp,112
+
+	maskeqz	$m2,$acc2,$n0
+	masknez	$d2,$t2,$n0
+	$REG_L	$s2,$sp,120
+	or	$m3,$m3,$d3
+
+	maskeqz	$m1,$acc1,$n0
+	masknez	$d1,$t1,$n0
+	or	$m2,$m2,$d2
+	$REG_L	$s1,$sp,128
+
+	maskeqz	$m0,$acc0,$n0
+	masknez	$d0,$t0,$n0
+	or	$m1,$m1,$d1
+	$REG_L	$s0,$sp,136
+
+
+	or	$m0,$m0,$d0
+	$ST	$m3,$rp,8*3
+	$ST	$m2,$rp,8*2
+	$PTR_ADD	$sp,$sp,160
+
+	$ST	$m1,$rp,8*1
+	$ST	$m0,$rp,8*0
+	li.d	$a0,1
+	jirl	$zero,$ra,0
+
+___
+$code =~ s/\`([^\`]*)\`/eval $1/gem;
+
+print $code;
+close STDOUT;

--- a/crypto/bn/asm/loongarch-mont.pl
+++ b/crypto/bn/asm/loongarch-mont.pl
@@ -91,11 +91,11 @@ ___
 $code.=<<___;
 	move	$fp,$sp
 	$LD	$n0,$n0,0
-	$LD	$bi,$bp,0	# bp[0]
-	$LD	$aj,$ap,0	# ap[0]
-	$LD	$nj,$np,0	# np[0]
+	$LD	$bi,$bp,0	// bp[0]
+	$LD	$aj,$ap,0	// ap[0]
+	$LD	$nj,$np,0	// np[0]
 
-	$PTR_ADD	$sp,$sp,-2*$BNSZ	# place for two extra words
+	$PTR_ADD	$sp,$sp,-2*$BNSZ	// place for two extra words
 	slli.d	$num,$num,`log($BNSZ)/log(2)`
 	li.d	$t8,-4096
 	$SUBU	$sp,$sp,$num
@@ -103,19 +103,19 @@ $code.=<<___;
 
 	$LD	$ahi,$ap,$BNSZ
 	$LD	$nhi,$np,$BNSZ
-	$MULD	$lo0,$aj,$bi
+	$MULD	$lo0,$aj,$bi	// ap[0] * bp[0]
 	$MULHD	$hi0,$aj,$bi
-	$MULD	$m1,$lo0,$n0
+	$MULD	$m1,$lo0,$n0	// "tp[0]" * n0
 
-	$MULD	$alo,$ahi,$bi
+	$MULD	$alo,$ahi,$bi	// ap[1] * bp[0]
 	$MULHD	$ahi,$ahi,$bi
 
-	$MULD	$lo1,$nj,$m1
+	$MULD	$lo1,$nj,$m1	// np[0] * m1
 	$MULHD	$hi1,$nj,$m1
 	$ADDU	$lo1,$lo1,$lo0
 	sltu	$t8,$lo1,$lo0
 	$ADDU	$hi1,$hi1,$t8
-	$MULD	$nlo,$nhi,$m1
+	$MULD	$nlo,$nhi,$m1	// np[1] * m1
 	$MULHD	$nhi,$nhi,$m1
 
 	move	$tp,$sp
@@ -124,8 +124,8 @@ $code.=<<___;
 .L1st:
 	$ADDU	$aj,$ap,$j
 	$ADDU	$nj,$np,$j
-	$LD	$aj,$aj,0
-	$LD	$nj,$nj,0
+	$LD	$aj,$aj,0		// ap[j]
+	$LD	$nj,$nj,0		// np[j]
 
 	$ADDU	$lo0,$alo,$hi0
 	$ADDU	$lo1,$nlo,$hi1
@@ -133,16 +133,16 @@ $code.=<<___;
 	sltu	$t0,$lo1,$hi1
 	$ADDU	$hi0,$ahi,$t8
 	$ADDU	$hi1,$nhi,$t0
-	$MULD	$alo,$aj,$bi
+	$MULD	$alo,$aj,$bi	// ap[j] * bp[0]
 	$MULHD	$ahi,$aj,$bi
 
 	$ADDU	$lo1,$lo1,$lo0
 	sltu	$t8,$lo1,$lo0
 	$ADDU	$hi1,$hi1,$t8
-	addi.d	$j,$j,$BNSZ
+	addi.d	$j,$j,$BNSZ		// j++
 	$ST	$lo1,$tp,0
-	sltu	$t0,$j,$num
-	$MULD	$nlo,$nj,$m1
+	sltu	$t0,$j,$num		// j < n
+	$MULD	$nlo,$nj,$m1	// np[j] * m1
 	$MULHD	$nhi,$nj,$m1
 
 	$PTR_ADD	$tp,$tp,$BNSZ
@@ -162,7 +162,7 @@ $code.=<<___;
 	$ST	$lo1,$tp,0
 
 	$ADDU	$hi1,$hi1,$hi0
-	sltu	$t8,$hi1,$hi0
+	sltu	$t8,$hi1,$hi0	// upmost overflow bit
 	$ST	$hi1,$tp,$BNSZ
 	$ST	$t8,$tp,2*$BNSZ
 
@@ -170,35 +170,35 @@ $code.=<<___;
 .align	4
 .Louter:
 	$ADDU	$bi,$bp,$i
-	$LD	$bi,$bi,0
-	$LD	$aj,$ap,0
-	$LD	$ahi,$ap,$BNSZ
-	$LD	$tj,$sp,0
+	$LD	$bi,$bi,0		// bp[i]
+	$LD	$aj,$ap,0		// ap[0]
+	$LD	$ahi,$ap,$BNSZ	// ap[1]
+	$LD	$tj,$sp,0		// tp[0]
 
 	$LD	$nj,$np,0
 	$LD	$nhi,$np,$BNSZ
-	$MULD	$lo0,$aj,$bi
+	$MULD	$lo0,$aj,$bi	// ap[0] * bp[i]
 	$MULHD	$hi0,$aj,$bi
 	$ADDU	$lo0,$lo0,$tj
 	sltu	$t8,$lo0,$tj
 	$ADDU	$hi0,$hi0,$t8
 	$MULD	$m1,$lo0,$n0
 
-	$MULD	$alo,$ahi,$bi
+	$MULD	$alo,$ahi,$bi	// ap[1] * bp[i]
 	$MULHD	$ahi,$ahi,$bi
 
-	$MULD	$lo1,$nj,$m1
+	$MULD	$lo1,$nj,$m1	// np[0] * m1
 	$MULHD	$hi1,$nj,$m1
 
 	$ADDU	$lo1,$lo1,$lo0
 	sltu	$t8,$lo1,$lo0
 	$ADDU	$hi1,$hi1,$t8
-	$MULD	$nlo,$nhi,$m1
+	$MULD	$nlo,$nhi,$m1	// np[1] * m1
 	$MULHD	$nhi,$nhi,$m1
 
 	move	$tp,$sp
 	li.d	$j,2*$BNSZ
-	$LD	$tj,$tp,$BNSZ
+	$LD	$tj,$tp,$BNSZ		// tp[j]
 .align	4
 .Linner:
 	$ADDU	$aj,$ap,$j
@@ -212,7 +212,7 @@ $code.=<<___;
 	sltu	$t0,$lo1,$hi1
 	$ADDU	$hi0,$ahi,$t8
 	$ADDU	$hi1,$nhi,$t0
-	$MULD	$alo,$aj,$bi
+	$MULD	$alo,$aj,$bi	// ap[j] * bp[i]
 	$MULHD	$ahi,$aj,$bi
 
 	$ADDU	$lo0,$lo0,$tj
@@ -221,12 +221,12 @@ $code.=<<___;
 	$ADDU	$lo1,$lo1,$lo0
 	$ADDU	$hi0,$hi0,$t8
 	sltu	$t0,$lo1,$lo0
-	$LD	$tj,$tp,2*$BNSZ
+	$LD	$tj,$tp,2*$BNSZ		// tp[j]
 	$ADDU	$hi1,$hi1,$t0
 	sltu	$t8,$j,$num
-	$MULD	$nlo,$nj,$m1
+	$MULD	$nlo,$nj,$m1	// np[j] * m1
 	$MULHD	$nhi,$nj,$m1
-	$ST	$lo1,$tp,0
+	$ST	$lo1,$tp,0		// tp[j - 1]
 	$PTR_ADD	$tp,$tp,$BNSZ
 	bnez	$t8,.Linner
 
@@ -258,10 +258,14 @@ $code.=<<___;
 	sltu	$t0,$i,$num
 	bnez	$t0,.Louter
 
-	$ADDU	$tj,$sp,$num	# &tp[num]
+    // Final step. We see if result is larger than modulus, and
+    // if it is, subtract the modulus. But comparison implies
+    // subtraction. So we subtract modulus, see if it borrowed,
+    // and conditionally copy original value.
+	$ADDU	$tj,$sp,$num	// &tp[num]
 	move	$tp,$sp
 	move	$ap,$sp
-	li.d	$hi0,0	# clear borrow bit
+	li.d	$hi0,0	// clear borrow bit
 
 .align	4
 .Lsub:
@@ -269,7 +273,7 @@ $code.=<<___;
 	$LD	$lo1,$np,0
 	$PTR_ADD	$tp,$tp,$BNSZ
 	$PTR_ADD	$np,$np,$BNSZ
-	$SUBU	$lo1,$lo0,$lo1	# tp[i]-np[i]
+	$SUBU	$lo1,$lo0,$lo1	// tp[i]-np[i]
 	sltu	$t8,$lo0,$lo1
 	$SUBU	$lo0,$lo1,$hi0
 	sltu	$hi0,$lo1,$lo0
@@ -278,12 +282,12 @@ $code.=<<___;
 	sltu	$t8,$tp,$tj
 	$PTR_ADD	$rp,$rp,$BNSZ
 	bnez	$t8,.Lsub
-	$SUBU	$hi0,$hi1,$hi0	# handle upmost overflow bit
+	$SUBU	$hi0,$hi1,$hi0	// handle upmost overflow bit
 	move	$tp,$sp
-	$SUBU	$rp,$rp,$num	# restore rp
+	$SUBU	$rp,$rp,$num	// restore rp
 	nor	$hi1,$hi0,$zero
 .Lcopy:
-	$LD	$nj,$tp,0	# conditional move
+	$LD	$nj,$tp,0	// conditional move
 	$LD	$aj,$rp,0
 	$ST	$zero,$tp,0
 	$PTR_ADD	$tp,$tp,$BNSZ
@@ -310,6 +314,11 @@ $code.=<<___;
 	$PTR_ADD	$sp,$sp,64;
 	jr	$ra
 ___
+
+########################################################################
+# Even though this might look as LoongArch64 adaptation of mulx4x_mont
+# from ARMV8 module, it's different in sense that it **ONLY** performs
+# reduction 256 bits, since LoongArch64 without enough registers
 
 $zero="\$r0";	#zero
 $ra="\$r1";	#ra
@@ -362,9 +371,9 @@ $t3="\$r31";    #s8
 
 $code.=<<___;
 .type __bn256_mul_mont,%function
+.align 4
 
 __bn256_mul_mont:
-.align 4
 	$PTR_ADD	$sp,$sp,-160
 	alsl.d	$bp_end,$num,$bp,3
 	$LD	$n0,$n0,0
@@ -400,36 +409,36 @@ __bn256_mul_mont:
 	$REG_S	$s6,$sp,88
 	$REG_S	$s7,$sp,80
 
-.Loop_mul4x_1st_reduction:
-	$MULD	$t0,$d0,$bi		//@4
+.Loop_mul4x_reduction:
+	$MULD	$t0,$d0,$bi		// @4
 	$MULD	$t1,$d1,$bi
 	$MULD	$t2,$d2,$bi
 	$MULD	$t3,$d3,$bi
 
 	$MULHD	$t4,$d0,$bi
 	$MULHD	$t5,$d1,$bi
-	$ADDU	$acc0,$acc0,$t0		//0 adds	$acc0,$acc0,LO($d0*$bi)
-	$ADDU	$acc1,$acc1,$t1		//1 adcs	$acc1,$acc1,LO($d1*$bi)
+	$ADDU	$acc0,$acc0,$t0		// adds	$acc0,$acc0,LO($d0*$bi)
+	$ADDU	$acc1,$acc1,$t1		// adcs	$acc1,$acc1,LO($d1*$bi)
 
 	$PTR_ADD	$bp,$bp,8
-	$MULD	$t6,$n0,$acc0		//$mi alias with $t6
-	sltu	$t0,$acc0,$t0		//done 0
+	$MULD	$t6,$n0,$acc0		// $mi alias with $t6
+	sltu	$t0,$acc0,$t0
 	sltu	$t1,$acc1,$t1
 
 	$ADDU	$acc1,$acc1,$t0
-	sltu	$t7,$zero,$acc0		//10 subs	$zero,$acc0,1
-	$ADDU	$acc2,$acc2,$t2		//2 adcs	$acc2,$acc2,LO($d2*$bi)
-	$ADDU	$acc3,$acc3,$t3		//3 adcs	$acc3,$acc3,LO($d3*$bi)
+	sltu	$t7,$zero,$acc0		// subs	$zero,$acc0,1
+	$ADDU	$acc2,$acc2,$t2		// adcs	$acc2,$acc2,LO($d2*$bi)
+	$ADDU	$acc3,$acc3,$t3		// adcs	$acc3,$acc3,LO($d3*$bi)
 
 
 	sltu	$t0,$acc1,$t0
-	$ADDU	$acc1,$acc1,$t4		//11 adds	$acc1,$acc1,HI($d0*$bi)
+	$ADDU	$acc1,$acc1,$t4		// adds	$acc1,$acc1,HI($d0*$bi)
 	sltu	$t2,$acc2,$t2
 	sltu	$t3,$acc3,$t3
 
-	or	$t0,$t0,$t1		//done 1
-	sltu	$t4,$acc1,$t4		//done 11
-	$ADDU	$acc0,$acc1,$t7		//20 adcs	$acc0,$acc1,LO($m1*$mi)
+	or	$t0,$t0,$t1
+	sltu	$t4,$acc1,$t4
+	$ADDU	$acc0,$acc1,$t7		// adcs	$acc0,$acc1,LO($m1*$mi)
 	$MULHD	$t1,$d2,$bi
 
 	$MULD	$t7,$m1,$t6
@@ -440,11 +449,11 @@ __bn256_mul_mont:
 	$MULHD	$t5,$d3,$bi
 	$MULD	$bi,$m2,$t6
 	sltu	$t0,$acc2,$t0
-	$ADDU	$acc2,$acc2,$t4		//12 adcs	$acc2,$acc2,HI($d1*$bi)
+	$ADDU	$acc2,$acc2,$t4		// adcs	$acc2,$acc2,HI($d1*$bi)
 
 
-	or	$t0,$t0,$t2		//done 2
-	sltu	$t4,$acc2,$t4		//done 12
+	or	$t0,$t0,$t2
+	sltu	$t4,$acc2,$t4
 	$MULD	$t2,$m3,$t6
 	$ADDU	$acc0,$acc0,$t7
 
@@ -454,73 +463,73 @@ __bn256_mul_mont:
 	$MULHD	$t1,$m0,$t6
 
 	sltu	$t0,$acc3,$t0
-	$ADDU	$acc3,$acc3,$t4		//13 adcs	$acc3,$acc3,HI($d2*$bi)
-	or	$t7,$acc1,$t7		//done 20
-	$ADDU	$acc1,$acc2,$bi		//21 adcs	$acc1,$acc2,LO($m2*$mi)
+	$ADDU	$acc3,$acc3,$t4		// adcs	$acc3,$acc3,HI($d2*$bi)
+	or	$t7,$acc1,$t7
+	$ADDU	$acc1,$acc2,$bi		// adcs	$acc1,$acc2,LO($m2*$mi)
 
-	or	$t0,$t0,$t3		//done 3,	adc $acc4,$zero,$zero
-	sltu	$t4,$acc3,$t4		//done 13
+	or	$t0,$t0,$t3			// adc $acc4,$zero,$zero
+	sltu	$t4,$acc3,$t4
 	sltu	$acc2,$acc1,$acc2
 	$MULHD	$t3,$m1,$t6
 
 	$ADDU	$t4,$t4,$t5
 	$ADDU	$acc1,$acc1,$t7
-	$ADDU	$acc3,$acc3,$t2		//22 adcs	$acc2,$acc3,LO($m3*$mi)
+	$ADDU	$acc3,$acc3,$t2		// adcs	$acc2,$acc3,LO($m3*$mi)
 	$MULHD	$t5,$m2,$t6
 
 
-	$ADDU	$t0,$t0,$t4		//14 addc	$acc4,$acc4,HI($d3*$bi)
+	$ADDU	$t0,$t0,$t4		// addc	$acc4,$acc4,HI($d3*$bi)
 	sltu	$t7,$acc1,$t7
 	sltu	$t2,$acc3,$t2
-	$ADDU	$acc0,$acc0,$t1		//30 adcs	$acc0,$acc0,HI($m0*$mi)
+	$ADDU	$acc0,$acc0,$t1		// adcs	$acc0,$acc0,HI($m0*$mi)
 
-	or	$t7,$acc2,$t7		//done 21
+	or	$t7,$acc2,$t7
 	sltu	$t1,$acc0,$t1
 	$LD	$bi,$bp,0
-	$ADDU	$t0,$t0,$carry  	//23 adcs	$acc3,$acc4,$carry
+	$ADDU	$t0,$t0,$carry  	// adcs	$acc3,$acc4,$carry
 
 	$ADDU	$acc2,$acc3,$t7
-	$ADDU	$t1,$t3,$t1		//done 30
+	$ADDU	$t1,$t3,$t1
 	$MULHD	$t6,$m3,$t6
 	sltu	$carry,$t0,$carry
 
 
 	sltu	$t7,$acc2,$acc3
-	$ADDU	$acc1,$acc1,$t1		//31 adcs	$acc1,$acc1,HI($m1*$mi)
+	$ADDU	$acc1,$acc1,$t1		// adcs	$acc1,$acc1,HI($m1*$mi)
 
-	or	$t7,$t2,$t7		//done 22
-	sltu	$t1,$acc1,$t1		//done 31
+	or	$t7,$t2,$t7
+	sltu	$t1,$acc1,$t1
 
 	$ADDU	$acc3,$t0,$t7
 	$ADDU	$t1,$t1,$t5
 
 	sltu	$t7,$acc3,$t7
-	$ADDU	$acc2,$acc2,$t1		//32 adcs	$acc2,$acc2,HI($m2*$mi)
+	$ADDU	$acc2,$acc2,$t1		// adcs	$acc2,$acc2,HI($m2*$mi)
 
-	or	$carry,$carry,$t7	//done 23, adc	$carry,$zero,$zero
-	sltu	$t1,$acc2,$t1		//done 32
+	or	$carry,$carry,$t7	// adc	$carry,$zero,$zero
+	sltu	$t1,$acc2,$t1
 
 	$ADDU	$t1,$t1,$t6
 
-	$ADDU	$acc3,$acc3,$t1		//33 adcs	$acc3,$acc3,HI($m3*$mi)
-	sltu	$t1,$acc3,$t1		//done 33
+	$ADDU	$acc3,$acc3,$t1		// adcs	$acc3,$acc3,HI($m3*$mi)
+	sltu	$t1,$acc3,$t1
 
-	$ADDU	$carry,$carry,$t1	//adc $carry,$carry,$zero
+	$ADDU	$carry,$carry,$t1	// adc $carry,$carry,$zero
 
-	bne	$bp,$bp_end,.Loop_mul4x_1st_reduction
+	bne	$bp,$bp_end,.Loop_mul4x_reduction
 
-	sltu	$n0,$acc0,$m0		//subs	$t0,$acc0,$m0
+	sltu	$n0,$acc0,$m0		// subs	$t0,$acc0,$m0
 	$SUBU	$t0,$acc0,$m0
-	sltu	$bp_end,$acc1,$m1	//sbcs	$t1,$acc1,$m1
+	sltu	$bp_end,$acc1,$m1	// sbcs	$t1,$acc1,$m1
 	$SUBU	$t1,$acc1,$m1
 
 	sltu	$m1,$t1,$n0
 	$SUBU	$t1,$t1,$n0
-	sltu	$bp,$acc2,$m2		//sbcs	$t2,$acc2,$m2
+	sltu	$bp,$acc2,$m2		// sbcs	$t2,$acc2,$m2
 	$SUBU	$t2,$acc2,$m2
 
 	or	$n0,$bp_end,$m1
-	sltu	$bp_end,$acc3,$m3	//sbcs	$t3,$acc3,$m3
+	sltu	$bp_end,$acc3,$m3	// sbcs	$t3,$acc3,$m3
 	$SUBU	$t3,$acc3,$m3
 
 	sltu	$m2,$t2,$n0
@@ -537,7 +546,7 @@ __bn256_mul_mont:
 
 	or	$n0,$bp_end,$m3
 
-	sltu	$n0,$carry,$n0		//sbcs	$zero,$carry,$zero
+	sltu	$n0,$carry,$n0		// sbcs	$zero,$carry,$zero
 
 	maskeqz	$m3,$acc3,$n0
 	masknez	$d3,$t3,$n0

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -47,6 +47,9 @@ IF[{- !$disabled{asm} -}]
   $BNASM_mips64=$BNASM_mips32
   $BNDEF_mips64=$BNDEF_mips32
 
+  $BNASM_loongarch64=bn_asm.c loongarch-mont.S
+  $BNDEF_loongarch64=OPENSSL_BN_ASM_MONT
+
   IF[{- ($target{perlasm_scheme} // '') eq '31' -}]
     $BNASM_s390x=bn_asm.c s390x-mont.S
   ELSE
@@ -133,6 +136,9 @@ GENERATE[bn-mips.S]=asm/mips.pl
 INCLUDE[bn-mips.o]=..
 GENERATE[mips-mont.S]=asm/mips-mont.pl
 INCLUDE[mips-mont.o]=..
+
+GENERATE[loongarch-mont.S]=asm/loongarch-mont.pl
+#INCLUDE[loongarch-mont.o]=..
 
 GENERATE[s390x-mont.S]=asm/s390x-mont.pl
 GENERATE[s390x-gf2m.s]=asm/s390x-gf2m.pl


### PR DESCRIPTION
Optimize bn_mul_mont to improve the performance of RSA and SM2, following is the test result on LA 3A6000 with option enable-ec_sm2p_64_gcc_128.
```
         sign/s verify/s  sign/s(optimized) verify/s(optimized)
rsa  512 8812.0 117007.0  21851.6(+148%)    217270.4(+86%)
rsa 1024 1700.5  36137.7   3262.6(+92%)      68838.6(+90%)
rsa 2048  265.2  10476.0    496.1(+87%)      17870.1(+71%)
rsa 3072   83.8   4565.8    148.0(+77%)       8323.2(+82%)
rsa 4096   40.2   2898.8     67.5(+68%)       4966.4(+71%)
rsa 7680    6.4    784.9     11.5(+80%)       1433.2(+86%)
rsa 15360   0.8    201.0      1.5(+88%)        366.7(+82%)

     sign/s   verify/s  sign/s(optimized) verify/s(optimized)
SM2  6891.3   4605.2     8800.6(+28%)     4608.8(+0%)
```

<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
