### PR TITLE
Change SM2DH-MLKEM768-HYBRID's tls_group_id to avoid occasional test …

### DIFF
--- a/include/internal/tlsgroups.h
+++ b/include/internal/tlsgroups.h
@@ -47,6 +47,13 @@
 # define OSSL_TLS_GROUP_ID_ffdhe4096        0x0102
 # define OSSL_TLS_GROUP_ID_ffdhe6144        0x0103
 # define OSSL_TLS_GROUP_ID_ffdhe8192        0x0104
-# define OSSL_TLS_GROUP_ID_sm2dh_mlkem768_hybrid 0xFEFE
+/* 
+    This tls_group_id (4590) has not been registered by
+    IANA, we temporarily use this value since it is 
+    unoccupied and aligns with the other hybrid tls_groups.
+    tls_group_id 65024-65279 are used by sslapitest
+    so cannot be used here (ref. randomize_tls_group_id).
+*/
+# define OSSL_TLS_GROUP_ID_sm2dh_mlkem768_hybrid 0x11EE
 
 #endif


### PR DESCRIPTION
Fix the problem of sslapitest failure.
The sslapitest test uses randomized tls_group number which allocates a random number between 65024-65279 per test. That value may equal to pervious SM2DH-MLKEM768-HYBIRD's nid 0xFEFE.
To solve this issue, we change the hybrid group's nid from 0xFEFE to 0x11EE, which is a value that has not been assigned by IANA (as well as not used by the other tongsuo tests).

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [x] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）
