### PR TITLE
config: remove obsolete VMS support

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -165,12 +165,6 @@ my $guess_patterns = [
     [ 'CYGWIN.*',                   '${MACHINE}-pc-cygwin' ],
     [ 'vxworks.*',                  '${MACHINE}-whatever-vxworks' ],
 
-    # The MACHINE part of the array POSIX::uname() returns on VMS isn't
-    # worth the bits wasted on it.  It's better, then, to rely on perl's
-    # %Config, which has a trustworthy item 'archname', especially since
-    # VMS installation aren't multiarch (yet)
-    [ 'OpenVMS:.*',                 "$Config{archname}-whatever-OpenVMS" ],
-
     # Note: there's also NEO and NSR, but they are old and unsupported
     [ 'NONSTOP_KERNEL:.*:NSE-.*?',  'nse-tandem-nsk${RELEASE}' ],
     [ 'NONSTOP_KERNEL:.*:NSV-.*?',  'nsv-tandem-nsk${RELEASE}' ],
@@ -786,11 +780,6 @@ _____
         }
       ],
 
-      # VMS values found by observation on existing machinery.
-      [ 'VMS_AXP-.*?-OpenVMS',    { target => 'vms-alpha'  } ],
-      [ 'VMS_IA64-.*?-OpenVMS',   { target => 'vms-ia64'   } ],
-      [ 'VMS_x86_64-.*?-OpenVMS', { target => 'vms-x86_64' } ],
- 
       # TODO: There are a few more choices among OpenSSL config targets, but
       # reaching them involves a bit more than just a host tripet.  Select
       # environment variables could do the job to cover for more granular


### PR DESCRIPTION
<!--
发起一个新Pull Request的通用原则：

1. 在PR的Description中明确说明此PR的作用
2. 如果此PR和某个Issue有关联，则需要进行显式关联，例如在PR中写明：Fixes #xxxx
3. 完成下列checklist的检查
-->

##### Checklist
<!-- 基于你的PR的实际情况移除不适用的项目。其他完成的项目修改[ ]为[x]. -->
- [ ] 在 https://yuque.com/tsdoc 增加或更新了必要的文档
- [ ] 增加或更新了必要的测试用例
- [ ] 对于重要修改，更新了CHANGES文件
- [ ] 当前修改存在对已有API参数或返回值的改变
- [ ] 当前修改存在对旧版本功能的兼容性改变（如网络协议或密码算法）

Since Tongsuo has dropped support for VMS, the VMS guessing logic and target mappings in `util/perl/OpenSSL/config.pm` are no longer needed.

This commit cleans up the dead code to match the current build system status.
