### PR TITLE
Add BoringSSL-style QUIC APIs

### DIFF
--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -3061,6 +3061,55 @@ __owur int SSL_CTX_get0_server_cert_type(const SSL_CTX *s, unsigned char **t, si
 # define OSSL_RECORD_PROTECTION_LEVEL_HANDSHAKE   2
 # define OSSL_RECORD_PROTECTION_LEVEL_APPLICATION 3
 
+/*
+ * BoringSSL style QUIC API.
+ */
+typedef enum ssl_encryption_level_t {
+    ssl_encryption_initial = 0,
+    ssl_encryption_early_data,
+    ssl_encryption_handshake,
+    ssl_encryption_application
+} OSSL_ENCRYPTION_LEVEL;
+
+#define OSSL_ENCRYPTION_LEVEL_NUM 4
+
+struct ssl_quic_api_method_st {
+    int (*set_read_secret)(SSL *ssl, enum ssl_encryption_level_t level,
+                           const SSL_CIPHER *cipher, const uint8_t *secret,
+                           size_t secret_len);
+    int (*set_write_secret)(SSL *ssl, enum ssl_encryption_level_t level,
+                            const SSL_CIPHER *cipher, const uint8_t *secret,
+                            size_t secret_len);
+    int (*add_handshake_data)(SSL *ssl, enum ssl_encryption_level_t level,
+                              const uint8_t *data, size_t len);
+    int (*flush_flight)(SSL *ssl);
+    int (*send_alert)(SSL *ssl, enum ssl_encryption_level_t level, uint8_t alert);
+};
+
+OSSL_ENCRYPTION_LEVEL SSL_quic_read_level(const SSL *s);
+OSSL_ENCRYPTION_LEVEL SSL_quic_write_level(const SSL *s);
+
+void SSL_set_quic_use_legacy_codepoint(SSL *s, int use_legacy);
+
+int SSL_set_quic_method(SSL *s, const SSL_QUIC_METHOD *quic_api_method);
+
+int SSL_provide_quic_data(SSL *s, OSSL_ENCRYPTION_LEVEL level,
+                          const uint8_t *data, size_t len);
+
+void SSL_get_peer_quic_transport_params(const SSL *ssl, const uint8_t **out_params, 
+                                        size_t *out_params_len);
+
+int SSL_process_quic_post_handshake(SSL *ssl);
+
+void SSL_set_quic_early_data_enabled(SSL *ssl, int enabled);
+
+int SSL_set_quic_early_data_context(SSL *ssl, const uint8_t *context,
+                                    size_t context_len);
+
+int SSL_set_quic_transport_params(SSL *ssl,
+                                 const uint8_t *params,
+                                 size_t params_len);
+
 int SSL_set_quic_tls_cbs(SSL *s, const OSSL_DISPATCH *qtdis, void *arg);
 int SSL_set_quic_tls_transport_params(SSL *s,
                                       const unsigned char *params,

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -205,6 +205,9 @@ typedef struct engine_st ENGINE;
 typedef struct ssl_st SSL;
 typedef struct ssl_ctx_st SSL_CTX;
 
+typedef struct ssl_quic_api_method_st SSL_QUIC_METHOD;
+typedef struct ssl_quic_api_info_st SSL_QUIC_API_INFO;
+
 # ifndef OPENSSL_NO_STATUS
 typedef struct ssl_status_st SSL_status;
 # endif

--- a/ssl/quic/build.info
+++ b/ssl/quic/build.info
@@ -1,7 +1,7 @@
 $LIBSSL=../../libssl
 
 #QUIC TLS API is available even in the event of no-quic
-SOURCE[$LIBSSL]=quic_tls.c quic_tls_api.c
+SOURCE[$LIBSSL]=quic_tls.c quic_tls_api.c quic_tls_api_method.c
 IF[{- !$disabled{quic} -}]
     SOURCE[$LIBSSL]=quic_method.c quic_impl.c quic_wire.c quic_ackm.c quic_statm.c
     SOURCE[$LIBSSL]=cc_newreno.c quic_demux.c quic_record_rx.c

--- a/ssl/quic/quic_tls_api.c
+++ b/ssl/quic/quic_tls_api.c
@@ -43,6 +43,7 @@ static int crypto_release_rcd_cb(size_t bytes_read, void *arg)
         return 0;
     return sc->qtcb.crypto_release_rcd_cb(s, bytes_read, sc->qtarg);
 }
+
 static int yield_secret_cb(uint32_t prot_level, int direction,
                            uint32_t suite_id, EVP_MD *md,
                            const unsigned char *secret, size_t secret_len,
@@ -143,6 +144,8 @@ int SSL_set_quic_tls_cbs(SSL *s, const OSSL_DISPATCH *qtdis, void *arg)
         /* ERR_raise already called */
         return 0;
 
+    if (sc->qtarg != NULL)
+        return 0;
     sc->qtarg = arg;
 
     ossl_quic_tls_free(sc->qtls);

--- a/ssl/quic/quic_tls_api_method.c
+++ b/ssl/quic/quic_tls_api_method.c
@@ -473,11 +473,19 @@ int SSL_set_quic_early_data_context(SSL *ssl, const uint8_t *context,
     return 1;
 }
 
-int SSL_set_quic_transport_params(SSL *ssl,
-                                 const uint8_t *params,
-                                 size_t params_len)
+int SSL_set_quic_transport_params(SSL *ssl, const uint8_t *params,
+                                  size_t params_len)
 {
-    return SSL_set_quic_tls_transport_params(ssl, params, params_len);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
+    if (sc == NULL || params == NULL || params_len == 0)
+        return 0;
+
+    OPENSSL_free(sc->quic_api_method_transport_params);
+    sc->quic_api_method_transport_params = OPENSSL_memdup(params, params_len);
+    sc->quic_api_method_transport_params_len = params_len;
+
+    return SSL_set_quic_tls_transport_params(ssl, sc->quic_api_method_transport_params,
+                                             sc->quic_api_method_transport_params_len);
 }
 
 void SSL_get_peer_quic_transport_params(const SSL *ssl, const uint8_t **out_params, 

--- a/ssl/quic/quic_tls_api_method.c
+++ b/ssl/quic/quic_tls_api_method.c
@@ -1,0 +1,511 @@
+/*
+ * Copyright 2026 The Tongsuo Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/ssl.h>
+#include "internal/ssl_unwrap.h"
+#include "internal/quic_tls.h"
+#include "../ssl_local.h"
+
+static int quic_api_method_crypto_send_cb(SSL *s, const unsigned char *buf, size_t buf_len,
+                                          size_t *consumed, void *arg)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    SSL_QUIC_API_INFO *quic_api_info;
+
+    if (sc == NULL || arg == NULL || sc->quic_api_method == NULL)
+        return 0;
+    if (sc->quic_api_method->add_handshake_data == NULL)
+        return 0;
+
+    quic_api_info = (SSL_QUIC_API_INFO *)arg;
+
+    if (sc->quic_api_method->add_handshake_data(s, quic_api_info->quic_write_level, buf, buf_len) == 1) {
+        *consumed = buf_len;
+        return 1;
+    } else
+        return 0;
+}
+
+/* This function should deal with different encryption_level */
+static int quic_api_method_crypto_recv_rcd_cb(SSL *s, const unsigned char **buf,
+                                              size_t *bytes_read, void *arg)
+{
+    int quic_read_level;
+    size_t rcd_start_index, rcd_end_index;
+
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    SSL_QUIC_API_INFO *api_info;
+
+    if (sc == NULL || arg == NULL || sc->quic_api_method == NULL)
+        return 0;
+    
+    api_info = (SSL_QUIC_API_INFO *)arg;
+
+    quic_read_level = (int)api_info->quic_read_level;
+    rcd_start_index = api_info->level_start_index[quic_read_level];
+    rcd_end_index = api_info->level_end_index[quic_read_level];
+
+    /* 
+     * quic_next_record_start != 0 means at least one complete handshake
+     * message has been parsed and is available to read. 
+     */
+    if (api_info->quic_next_record_start != 0 && api_info->quic_buf != NULL) {
+        *buf = (unsigned char *)(api_info->quic_buf->data + rcd_start_index);
+        *bytes_read = (rcd_end_index - rcd_start_index);
+        api_info->level_start_index[quic_read_level] = rcd_end_index;
+    } else {
+        *bytes_read = 0;
+    }
+
+    return 1;
+}
+
+static int quic_api_method_crypto_release_rcd_cb(SSL *s, size_t bytes_read, void *arg)
+{
+    int i;
+
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    SSL_QUIC_API_INFO *api_info;
+
+    if (sc == NULL || arg == NULL || sc->quic_api_method == NULL)
+        return 0;
+
+    api_info = (SSL_QUIC_API_INFO *)arg;
+
+    /* We should never release more data than we have buffered */
+    if ((api_info->quic_buf == NULL && bytes_read > 0)
+        || api_info->quic_buf->length < api_info->quic_buf_released + bytes_read) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    api_info->quic_buf_released += bytes_read;
+
+     /* All data has been released, we can free the buffer */
+    if (api_info->quic_buf->length == api_info->quic_buf_released) {
+        BUF_MEM_free(api_info->quic_buf);
+        api_info->quic_buf = NULL;
+        api_info->quic_buf_released = 0;
+        api_info->quic_next_record_start = 0;
+        for (i = 0; i < OSSL_ENCRYPTION_LEVEL_NUM; ++i) {
+            api_info->level_start_index[i] = 0;
+            api_info->level_end_index[i] = 0;
+        }
+    }
+   
+    return 1;
+}
+
+static int quic_api_method_crypto_yield_secret_cb(SSL *s, uint32_t prot_level, int direction,
+                                                  const unsigned char *secret, size_t secret_len, void *arg)
+{
+    int ret = 0;
+
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    SSL_QUIC_API_INFO *api_info;
+
+    if (sc == NULL || arg == NULL || sc->quic_api_method == NULL)
+        return 0;
+    
+    api_info = (SSL_QUIC_API_INFO *)arg;
+
+    if (sc->quic_api_method->set_read_secret == NULL
+        || sc->quic_api_method->set_write_secret == NULL)
+        return 0;
+
+    if (prot_level < OSSL_RECORD_PROTECTION_LEVEL_EARLY
+        || prot_level > OSSL_RECORD_PROTECTION_LEVEL_APPLICATION)
+        return 0;
+
+    switch (direction) {
+    case 0: /* read */
+        api_info->quic_read_level = (OSSL_ENCRYPTION_LEVEL)prot_level;
+        ret = sc->quic_api_method->set_read_secret(s, api_info->quic_read_level, 
+                                                   SSL_get_current_cipher(s), secret, secret_len);
+        break;
+    case 1: /* write */
+        api_info->quic_write_level = (OSSL_ENCRYPTION_LEVEL)prot_level;
+        ret = sc->quic_api_method->set_write_secret(s, api_info->quic_write_level, 
+                                                   SSL_get_current_cipher(s), secret, secret_len);
+        break;
+    default:
+        return 0;
+    }
+
+    return ret;
+}
+
+static int quic_api_method_crypto_got_transport_params_cb(SSL *s, const unsigned char *params, 
+                                                          size_t params_len, void *arg)
+{
+    BUF_MEM *buf = NULL;
+
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    SSL_QUIC_API_INFO *api_info;
+
+    if (sc == NULL || arg == NULL || sc->quic_api_method == NULL)
+        return 0;
+    
+    api_info = (SSL_QUIC_API_INFO *)arg;
+
+    if (api_info->quic_transport_params_buf != NULL) {
+        BUF_MEM_free(api_info->quic_transport_params_buf);
+        api_info->quic_transport_params_buf = NULL;
+    }
+
+    if ((buf = BUF_MEM_new()) == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    if (!BUF_MEM_grow(buf, params_len)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        BUF_MEM_free(buf);
+        return 0;
+    }
+
+    api_info->quic_transport_params_buf = buf;
+    buf = NULL;
+
+    memcpy(api_info->quic_transport_params_buf->data, params, params_len);
+
+    return 1;
+}
+
+static int quic_api_method_crypto_alert_cb(SSL *s, unsigned char alert_code, void *arg)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    SSL_QUIC_API_INFO *api_info;
+
+    if (sc == NULL || arg == NULL || sc->quic_api_method == NULL)
+        return 0;
+
+    if (sc->quic_api_method->send_alert == NULL)
+        return 0;
+    
+    api_info = (SSL_QUIC_API_INFO *)arg;
+
+    return sc->quic_api_method->send_alert(s, api_info->quic_write_level, alert_code);
+}
+
+OSSL_ENCRYPTION_LEVEL SSL_quic_read_level(const SSL *s) 
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    SSL_QUIC_API_INFO *api_info;
+
+    if (sc == NULL)
+        return 0;
+
+    if (!SSL_IS_QUIC_HANDSHAKE(sc) 
+        || sc->quic_api_method == NULL 
+        || sc->qtarg == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    api_info = (SSL_QUIC_API_INFO *)sc->qtarg;
+
+    return api_info->quic_read_level;
+}
+
+OSSL_ENCRYPTION_LEVEL SSL_quic_write_level(const SSL *s)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    SSL_QUIC_API_INFO *api_info;
+
+    if (sc == NULL)
+        return 0;
+
+    if (!SSL_IS_QUIC_HANDSHAKE(sc) 
+        || sc->quic_api_method == NULL 
+        || sc->qtarg == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    api_info = (SSL_QUIC_API_INFO *)sc->qtarg;
+
+    return api_info->quic_write_level;
+}
+
+void SSL_set_quic_use_legacy_codepoint(SSL *s, int use_legacy)
+{
+    /* 
+        Empty implementation for the compatibility with XQUIC.
+        TODO: Remove this function, since RFC 9000 has been published.
+     */
+    (void)s;
+    (void)use_legacy;
+}
+
+int SSL_set_quic_method(SSL *s, const SSL_QUIC_METHOD *quic_api_method)
+{
+    OSSL_DISPATCH quic_api_method_cbs[] = {
+        {OSSL_FUNC_SSL_QUIC_TLS_CRYPTO_SEND, 
+         (void (*)(void))quic_api_method_crypto_send_cb},
+        {OSSL_FUNC_SSL_QUIC_TLS_CRYPTO_RECV_RCD,
+         (void (*)(void))quic_api_method_crypto_recv_rcd_cb},
+        {OSSL_FUNC_SSL_QUIC_TLS_CRYPTO_RELEASE_RCD,
+         (void (*)(void))quic_api_method_crypto_release_rcd_cb},
+        {OSSL_FUNC_SSL_QUIC_TLS_YIELD_SECRET,
+         (void (*)(void))quic_api_method_crypto_yield_secret_cb},
+        {OSSL_FUNC_SSL_QUIC_TLS_GOT_TRANSPORT_PARAMS,
+         (void (*)(void))quic_api_method_crypto_got_transport_params_cb},
+        {OSSL_FUNC_SSL_QUIC_TLS_ALERT, 
+         (void (*)(void))quic_api_method_crypto_alert_cb},
+        {0, NULL}
+    };
+
+    SSL_QUIC_API_INFO *quic_api_method_info;
+
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return 0;
+
+    /* This is de-allocated by ossl_ssl_connection_free when sc->quic_api_method != NULL. */
+    if ((quic_api_method_info = OPENSSL_zalloc(sizeof(SSL_QUIC_API_INFO))) == NULL )
+        return 0;
+
+    if (SSL_set_quic_tls_cbs(s, quic_api_method_cbs, quic_api_method_info) != 1){
+        OPENSSL_free(quic_api_method_info);
+        return 0;
+    }
+
+    sc->quic_api_method = quic_api_method;
+    return 1;
+}
+
+int SSL_provide_quic_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
+                          const uint8_t *data, size_t len)
+{
+    size_t offset, l;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
+    SSL_QUIC_API_INFO * api_info;
+
+    if (sc == NULL)
+        return 0;
+
+    if (!SSL_IS_QUIC_HANDSHAKE(sc) 
+        || sc->quic_api_method == NULL 
+        || sc->qtarg == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    if (len == 0)
+        return 1;
+
+    api_info = (SSL_QUIC_API_INFO *)sc->qtarg;
+
+    if (level < ssl_encryption_initial || level > ssl_encryption_application) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    if (level < api_info->quic_read_level || level < api_info->quic_latest_level_received) {
+        ERR_raise(ERR_LIB_SSL, SSL_R_QUIC_PROTOCOL_ERROR);
+        return 0;
+    }
+        
+    if (api_info->quic_buf == NULL) {
+        BUF_MEM *buf;
+        if ((buf = BUF_MEM_new()) == NULL) {
+            ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+        if (!BUF_MEM_grow(buf, SSL3_RT_MAX_PLAIN_LENGTH)) {
+            ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+            BUF_MEM_free(buf);
+            return 0;
+        }
+        api_info->quic_buf = buf;
+        api_info->quic_buf->length = 0;
+        api_info->quic_buf_released = 0;
+        api_info->quic_next_record_start = 0;
+
+        api_info->level_start_index[api_info->quic_read_level] = 0;
+        api_info->level_end_index[api_info->quic_read_level] = 0;
+
+        buf = NULL;
+    }
+
+    /*  A TLS message must not cross an encryption level boundary */
+    if (api_info->quic_buf->length != api_info->quic_next_record_start 
+       && level != api_info->quic_latest_level_received) {
+        ERR_raise(ERR_LIB_SSL, SSL_R_QUIC_PROTOCOL_ERROR);
+        return 0;
+    }
+
+    offset = api_info->quic_buf->length;
+    /* 
+     * Update the latest received record's encryption level
+     * The current message is a new one.
+     */
+    if (level > api_info->quic_latest_level_received) {
+        api_info->quic_latest_level_received = level;
+        api_info->level_start_index[level] = offset;
+        api_info->level_end_index[level] = offset;
+    }
+
+    if (!BUF_MEM_grow(api_info->quic_buf, offset + len)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    memcpy(api_info->quic_buf->data + offset, data, len);
+
+    /* Split on handshake message boundaries */
+    while(api_info->quic_buf->length > api_info->quic_next_record_start 
+                                       + SSL3_HM_HEADER_LENGTH) {
+        const uint8_t *p;
+
+        /* TLS Handshake message header has 1-byte type and 3-byte length. */
+        p = (const uint8_t *)api_info->quic_buf->data + api_info->quic_next_record_start + 1; 
+        n2l3(p, l);
+        l += SSL3_HM_HEADER_LENGTH;
+
+        /* Don't allocate a new quic record if we don't have a full handshake message */
+        if (l > (api_info->quic_buf->length - api_info->quic_next_record_start))
+            break;
+        
+        api_info->level_end_index[level] += l;
+        api_info->quic_next_record_start += l;
+    }
+
+    return 1;
+}
+
+int SSL_process_quic_post_handshake(SSL *ssl)
+{
+    int ret = 0;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
+    SSL_QUIC_API_INFO * api_info;
+
+    if (sc == NULL || SSL_in_init(ssl))
+        return 0;
+
+    if (!SSL_IS_QUIC_HANDSHAKE(sc) 
+        || sc->quic_api_method == NULL 
+        || sc->qtarg == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    api_info = (SSL_QUIC_API_INFO *)sc->qtarg;
+
+    /* 
+     * Another approach: process a single post-handshake message with "if" 
+     * rather than while which may raise the problem of infinite loop.
+     * However, such modification changes the syntax of original
+     * SSL_process_quic_post_handshake which processes multiple messages per call.
+     */
+    while (api_info->quic_buf != NULL) {
+        ossl_statem_set_in_init(sc, 1);
+        ret = sc->handshake_func(ssl);
+        ossl_statem_set_in_init(sc, 0);
+
+        if (ret <= 0)
+            return 0;
+    }
+
+    return 1;
+}
+
+void SSL_set_quic_early_data_enabled(SSL *ssl, int enabled)
+{
+    /* Almost the same with ossl_quic_tls_set_early_data_enabled (quic_tls.c) */
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
+
+    if (sc == NULL || !SSL_IS_QUIC_HANDSHAKE(sc) || !SSL_in_before(ssl))
+        return;
+
+    if (!enabled) {
+        sc->max_early_data = 0;
+        sc->early_data_state = SSL_EARLY_DATA_NONE;
+        return;
+    }
+
+    if (sc->server) {
+        sc->max_early_data = 0xffffffff;
+        sc->early_data_state = SSL_EARLY_DATA_ACCEPTING;
+    }
+
+    if ((sc->session == NULL || sc->session->ext.max_early_data != 0xffffffff)
+        && sc->psk_use_session_cb == NULL){
+        return;
+    }
+    sc->early_data_state = SSL_EARLY_DATA_CONNECTING;
+}
+
+int SSL_set_quic_early_data_context(SSL *ssl, const uint8_t *context,
+                                    size_t context_len)
+{
+    uint8_t *tmp;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
+
+    if (sc == NULL)
+        return 0;
+
+    if (context == NULL || context_len == 0) {
+        tmp = NULL;
+        context_len = 0;
+    } else {
+        tmp = OPENSSL_memdup(context, context_len);
+        if (tmp == NULL)
+            return 0;
+    }
+
+    OPENSSL_free(sc->quic_early_data_context);
+    sc->quic_early_data_context = tmp;
+    sc->quic_early_data_context_len = context_len;
+
+    return 1;
+}
+
+int SSL_set_quic_transport_params(SSL *ssl,
+                                 const uint8_t *params,
+                                 size_t params_len)
+{
+    return SSL_set_quic_tls_transport_params(ssl, params, params_len);
+}
+
+void SSL_get_peer_quic_transport_params(const SSL *ssl, const uint8_t **out_params, 
+                                        size_t *out_params_len)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
+
+    SSL_QUIC_API_INFO * api_info;
+
+    if (sc == NULL)
+        return;
+
+    if (!SSL_IS_QUIC_HANDSHAKE(sc) 
+        || sc->quic_api_method == NULL 
+        || sc->qtarg == NULL) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
+        return;
+    }
+
+    api_info = (SSL_QUIC_API_INFO *)sc->qtarg;
+
+    if (api_info->quic_transport_params_buf != NULL) {
+        *out_params = (const uint8_t *)api_info->quic_transport_params_buf->data;
+        *out_params_len = api_info->quic_transport_params_buf->length;
+    } else {
+        *out_params = NULL;
+        *out_params_len = 0;
+    }
+
+    return;
+}

--- a/ssl/quic/quic_tls_api_method.c
+++ b/ssl/quic/quic_tls_api_method.c
@@ -439,6 +439,7 @@ void SSL_set_quic_early_data_enabled(SSL *ssl, int enabled)
     if (sc->server) {
         sc->max_early_data = 0xffffffff;
         sc->early_data_state = SSL_EARLY_DATA_ACCEPTING;
+        return;
     }
 
     if ((sc->session == NULL || sc->session->ext.max_early_data != 0xffffffff)

--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -46,6 +46,7 @@ typedef struct {
     ASN1_OCTET_STRING *ticket_appdata;
     uint32_t kex_group;
     ASN1_OCTET_STRING *peer_rpk;
+    ASN1_OCTET_STRING *quic_early_data_context;
 } SSL_SESSION_ASN1;
 
 ASN1_SEQUENCE(SSL_SESSION_ASN1) = {
@@ -78,7 +79,8 @@ ASN1_SEQUENCE(SSL_SESSION_ASN1) = {
     ASN1_EXP_OPT_EMBED(SSL_SESSION_ASN1, tlsext_max_fragment_len_mode, ZUINT32, 17),
     ASN1_EXP_OPT(SSL_SESSION_ASN1, ticket_appdata, ASN1_OCTET_STRING, 18),
     ASN1_EXP_OPT_EMBED(SSL_SESSION_ASN1, kex_group, UINT32, 19),
-    ASN1_EXP_OPT(SSL_SESSION_ASN1, peer_rpk, ASN1_OCTET_STRING, 20)
+    ASN1_EXP_OPT(SSL_SESSION_ASN1, peer_rpk, ASN1_OCTET_STRING, 20),
+    ASN1_EXP_OPT(SSL_SESSION_ASN1, quic_early_data_context, ASN1_OCTET_STRING, 21),
 } static_ASN1_SEQUENCE_END(SSL_SESSION_ASN1)
 
 IMPLEMENT_STATIC_ASN1_ENCODE_FUNCTIONS(SSL_SESSION_ASN1)
@@ -129,6 +131,8 @@ int i2d_SSL_SESSION(const SSL_SESSION *in, unsigned char **pp)
     ASN1_OCTET_STRING alpn_selected;
     ASN1_OCTET_STRING ticket_appdata;
     ASN1_OCTET_STRING peer_rpk;
+
+    ASN1_OCTET_STRING quic_early_data_context;
 
     long l;
     int ret;
@@ -216,6 +220,12 @@ int i2d_SSL_SESSION(const SSL_SESSION *in, unsigned char **pp)
     else
         ssl_session_oinit(&as.ticket_appdata, &ticket_appdata,
                           in->ticket_appdata, in->ticket_appdata_len);
+
+    if (in->quic_early_data_context == NULL)
+        as.quic_early_data_context = NULL;
+    else
+        ssl_session_oinit(&as.quic_early_data_context, &quic_early_data_context,
+                          in->quic_early_data_context, in->quic_early_data_context_len);
 
     ret = i2d_SSL_SESSION_ASN1(&as, pp);
     OPENSSL_free(peer_rpk.data);
@@ -419,6 +429,16 @@ SSL_SESSION *d2i_SSL_SESSION_ex(SSL_SESSION **a, const unsigned char **pp,
     } else {
         ret->ticket_appdata = NULL;
         ret->ticket_appdata_len = 0;
+    }
+
+    OPENSSL_free(ret->quic_early_data_context);
+    if (as->quic_early_data_context != NULL) {
+        ret->quic_early_data_context = as->quic_early_data_context->data;
+        ret->quic_early_data_context_len = as->quic_early_data_context->length;
+        as->quic_early_data_context->data = NULL;
+    } else {
+        ret->quic_early_data_context = NULL;
+        ret->quic_early_data_context_len = 0;
     }
 
     M_ASN1_free_of(as, SSL_SESSION_ASN1);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1595,6 +1595,15 @@ void ossl_ssl_connection_free(SSL *ssl)
     BIO_free_all(s->rbio);
     s->rbio = NULL;
     OPENSSL_free(s->s3.tmp.valid_flags);
+
+    if(s->quic_api_method != NULL) {
+        SSL_QUIC_API_INFO *info = (SSL_QUIC_API_INFO *)s->qtarg;
+        BUF_MEM_free(info->quic_buf);
+        BUF_MEM_free(info->quic_transport_params_buf);
+        OPENSSL_free(s->qtarg);
+        s->qtarg = NULL;
+    }   
+    OPENSSL_free(s->quic_early_data_context);
 }
 
 void SSL_set0_rbio(SSL *s, BIO *rbio)
@@ -5797,10 +5806,6 @@ SSL_CTX *SSL_CTX_dup(SSL_CTX *ctx)
 
     ret->async_cb = ctx->async_cb;
     ret->async_cb_arg = ctx->async_cb_arg;
-
-#ifndef OPENSSL_NO_QUIC
-    /* ret->quic_method = ctx->quic_method; */
-#endif
 
 #ifndef OPENSSL_NO_CERT_COMPRESSION
     /*

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1603,6 +1603,7 @@ void ossl_ssl_connection_free(SSL *ssl)
         OPENSSL_free(s->qtarg);
         s->qtarg = NULL;
     }   
+    OPENSSL_free(s->quic_api_method_transport_params);
     OPENSSL_free(s->quic_early_data_context);
 }
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1337,6 +1337,15 @@ struct ssl_connection_st {
 
     /* QUIC API method */
     const SSL_QUIC_METHOD *quic_api_method;
+    /* 
+     * BoringSSL style QUIC-API allows the SSL_set_quic_transport_params
+     * caller to use the buffer for other purposes after calling, 
+     * but OpenSSL's API does not.
+     * We use a temporary buffer to accommodate both API styles. 
+     */
+    uint8_t *quic_api_method_transport_params;
+    size_t quic_api_method_transport_params_len;
+
     /* QUIC early data context */
     uint8_t *quic_early_data_context;
     size_t quic_early_data_context_len;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -538,6 +538,9 @@ struct ssl_session_st {
      */
     struct ssl_session_st *prev, *next;
     CRYPTO_REF_COUNT references;
+
+    uint8_t *quic_early_data_context;
+    size_t quic_early_data_context_len;
 };
 
 /* Extended master secret support */
@@ -1223,6 +1226,19 @@ typedef struct ossl_quic_tls_callbacks_st {
     int (*alert_cb)(SSL *s, unsigned char alert_code, void *arg);
 } OSSL_QUIC_TLS_CALLBACKS;
 
+struct ssl_quic_api_info_st {
+    /* Current Read/Write Level */
+    OSSL_ENCRYPTION_LEVEL quic_read_level;
+    OSSL_ENCRYPTION_LEVEL quic_write_level;
+    OSSL_ENCRYPTION_LEVEL quic_latest_level_received;
+    BUF_MEM *quic_buf;
+    BUF_MEM *quic_transport_params_buf;
+    size_t quic_next_record_start;
+    size_t quic_buf_released;
+    size_t level_start_index[OSSL_ENCRYPTION_LEVEL_NUM];
+    size_t level_end_index[OSSL_ENCRYPTION_LEVEL_NUM];
+};
+
 #ifndef OPENSSL_NO_DELEGATED_CREDENTIAL
 typedef struct dc_pkey_st DC_PKEY;
 #endif
@@ -1318,6 +1334,12 @@ struct ssl_connection_st {
     OSSL_QUIC_TLS_CALLBACKS qtcb;
     void *qtarg;
     QUIC_TLS *qtls;
+
+    /* QUIC API method */
+    const SSL_QUIC_METHOD *quic_api_method;
+    /* QUIC early data context */
+    uint8_t *quic_early_data_context;
+    size_t quic_early_data_context_len;
 
     struct {
         long flags;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -177,6 +177,9 @@ static SSL_SESSION *ssl_session_dup_intern(const SSL_SESSION *src, int ticket)
     dest->next = NULL;
     dest->owner = NULL;
 
+    dest->quic_early_data_context = NULL;
+    dest->quic_early_data_context_len = 0;
+
     if (!CRYPTO_NEW_REF(&dest->references, 1)) {
         OPENSSL_free(dest);
         return NULL;
@@ -272,6 +275,16 @@ static SSL_SESSION *ssl_session_dup_intern(const SSL_SESSION *src, int ticket)
             OPENSSL_memdup(src->ticket_appdata, src->ticket_appdata_len);
         if (dest->ticket_appdata == NULL)
             goto err;
+    }
+
+    if (src->quic_early_data_context) {
+        dest->quic_early_data_context =
+                OPENSSL_memdup(src->quic_early_data_context,
+                               src->quic_early_data_context_len);
+        if (dest->quic_early_data_context == NULL)
+            goto err;
+
+        dest->quic_early_data_context_len = src->quic_early_data_context_len;
     }
 
     return dest;
@@ -499,6 +512,19 @@ int ssl_get_new_session(SSL_CONNECTION *s, int session)
     s->session = ss;
     ss->ssl_version = s->version;
     ss->verify_result = X509_V_OK;
+
+    if (s->quic_early_data_context) {
+        ss->quic_early_data_context =
+                OPENSSL_memdup(s->quic_early_data_context,
+                               s->quic_early_data_context_len);
+        if (ss->quic_early_data_context == NULL) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
+            SSL_SESSION_free(ss);
+            return 0;
+        }
+ 
+        ss->quic_early_data_context_len = s->quic_early_data_context_len;
+    }
 
     /* If client supports extended master secret set it in session */
     if (s->s3.flags & TLS1_FLAGS_RECEIVED_EXTMS)
@@ -921,6 +947,7 @@ void SSL_SESSION_free(SSL_SESSION *ss)
 #ifndef OPENSSL_NO_SRP
     OPENSSL_free(ss->srp_username);
 #endif
+    OPENSSL_free(ss->quic_early_data_context);
     OPENSSL_free(ss->ext.alpn_selected);
     OPENSSL_free(ss->ticket_appdata);
     CRYPTO_FREE_REF(&ss->references);

--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -159,6 +159,14 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
             goto err;
     }
 
+    if (x->quic_early_data_context) {
+        if (BIO_puts(bp, "    QUIC early data ctx:\n") <= 0)
+            goto err;
+        if (BIO_dump_indent(bp, (const char *)x->quic_early_data_context,
+                            (int)x->quic_early_data_context_len, 4) <= 0)
+            goto err;
+    }
+
     return 1;
  err:
     return 0;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -36,6 +36,8 @@
                          + SSL_MAX_SSL_SESSION_ID_LENGTH + 2 + 1 + 2 + 6 + 4 \
                          + MAX_COOKIE_SIZE)
 
+static int quic_ticket_compatible(const SSL_SESSION *session, const SSL_CONNECTION *s);
+
 /*
  * Parse the client's renegotiation binding and abort if it's not right
  */
@@ -1529,6 +1531,10 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
                  */
                 s->ext.early_data_ok = 1;
             }
+            if (SSL_IS_QUIC_HANDSHAKE(s)) {
+                if (!quic_ticket_compatible(sess, s))
+                    s->ext.early_data_ok = 0;
+            }
         }
 
         md = ssl_md(sctx, sess->cipher->algorithm2);
@@ -2449,4 +2455,22 @@ int tls_parse_ctos_server_cert_type(SSL_CONNECTION *sc, PACKET *pkt,
     /* Did not receive an acceptable cert type */
     SSLfatal(sc, SSL_AD_UNSUPPORTED_CERTIFICATE, SSL_R_BAD_EXTENSION);
     return 0;
+}
+
+static int quic_ticket_compatible(const SSL_SESSION *session, const SSL_CONNECTION *s)
+{
+    if (session->quic_early_data_context == NULL && 
+        s->quic_early_data_context == NULL)
+        return 1;
+
+    if (session->quic_early_data_context == NULL ||
+        s->quic_early_data_context_len !=
+        session->quic_early_data_context_len ||
+        CRYPTO_memcmp(s->quic_early_data_context,
+                      session->quic_early_data_context,
+                      session->quic_early_data_context_len) != 0) {
+        return 0;
+    }
+
+    return 1;
 }

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -744,6 +744,12 @@ CON_FUNC_RETURN tls_construct_finished(SSL_CONNECTION *s, WPACKET *pkt)
 
 CON_FUNC_RETURN tls_construct_key_update(SSL_CONNECTION *s, WPACKET *pkt)
 {
+    if (SSL_IS_QUIC_HANDSHAKE(s)) {
+        /* TLS KeyUpdate is not used for QUIC, so this is an error. */
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return CON_FUNC_ERROR;
+    }
+
     if (!WPACKET_put_bytes_u8(pkt, s->key_update)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return CON_FUNC_ERROR;
@@ -756,6 +762,12 @@ CON_FUNC_RETURN tls_construct_key_update(SSL_CONNECTION *s, WPACKET *pkt)
 MSG_PROCESS_RETURN tls_process_key_update(SSL_CONNECTION *s, PACKET *pkt)
 {
     unsigned int updatetype;
+
+    if (SSL_IS_QUIC_HANDSHAKE(s)) {
+        /* TLS KeyUpdate is not used for QUIC, so this is an error. */
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return MSG_PROCESS_ERROR;
+    }
 
     /*
      * A KeyUpdate message signals a key change so the end of the message must

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -13211,6 +13211,281 @@ static int test_quic_tls_early_data(void)
 
     return testresult;
 }
+
+static int quic_api_test_alert = 0;
+
+
+struct quic_tls_api_test_data {
+    unsigned char rsecret[3][48];
+    size_t rsecret_len[3];
+    unsigned char wsecret[3][48];
+    size_t wsecret_len[3];
+};
+
+static struct quic_tls_api_test_data csecdata, ssecdata;
+
+static int quic_api_set_read_secret(SSL *ssl,
+                                    OSSL_ENCRYPTION_LEVEL level,
+                                    const SSL_CIPHER *cipher,
+                                    const uint8_t *secret,
+                                    size_t secret_len)
+{
+    int index = (int)level - 1;
+
+    if (SSL_is_server(ssl)) {
+        ssecdata.rsecret_len[index] = secret_len;
+        memcpy(&ssecdata.rsecret[index], secret, secret_len);
+    } else {
+        csecdata.rsecret_len[index] = secret_len;
+        memcpy(&csecdata.rsecret[index], secret, secret_len);
+    }
+
+    return 1;
+}
+
+static int quic_api_set_write_secret(SSL *ssl,
+                                     OSSL_ENCRYPTION_LEVEL level,
+                                     const SSL_CIPHER *cipher,
+                                     const uint8_t *secret,
+                                     size_t secret_len)
+{
+    int index = (int)level - 1;
+
+    if (SSL_is_server(ssl)) {
+        ssecdata.wsecret_len[index] = secret_len;
+        memcpy(&ssecdata.wsecret[index], secret, secret_len);
+    } else {
+        csecdata.wsecret_len[index] = secret_len;
+        memcpy(&csecdata.wsecret[index], secret, secret_len);
+    }
+
+    return 1;
+}
+
+static int quic_api_add_handshake_data(SSL *ssl, OSSL_ENCRYPTION_LEVEL level,
+                                       const uint8_t *data, size_t len)
+{
+    SSL *peer = (SSL*)SSL_get_app_data(ssl);
+
+    if(!TEST_ptr(peer))
+        return 0;
+    
+    /* For SSL_provide_quic_data, we should test different pattern. */
+    if (!TEST_true(SSL_provide_quic_data(peer, level, data, len)))
+        return 0;
+
+    return 1;
+}
+
+static int quic_api_flush_flight(SSL *ssl)
+{
+    return 1;
+}
+
+static int quic_api_send_alert(SSL *ssl, OSSL_ENCRYPTION_LEVEL level, uint8_t alert)
+{
+    if (alert != 0)
+        quic_api_test_alert = 1;
+    return 1;
+}
+
+/* In real applications, these methods are provided by the QUIC implementation. */
+static SSL_QUIC_METHOD quic_api_method = {
+    quic_api_set_read_secret,
+    quic_api_set_write_secret,
+    quic_api_add_handshake_data,
+    quic_api_flush_flight,
+    quic_api_send_alert
+};
+
+static int test_quic_tls_api_method(void)
+{
+    int testresult = 0, i;
+    SSL_CTX *sctx = NULL, *cctx = NULL;
+    SSL *serverssl = NULL, *clientssl = NULL;
+    SSL_SESSION *sess = NULL;
+
+    const unsigned char cparams[] = {
+        0xff, 0x01, 0x00
+    };
+    const unsigned char sparams[] = {
+        0xfe, 0x01, 0x00
+    };
+
+    const unsigned char *cpeerparams = NULL, *speerparams = NULL;
+    size_t cpeerparams_length = 0, speerparams_length = 0;
+    int cm_count = 0, sm_count = 0;
+
+    const unsigned char *early_data_context = (const unsigned char *)"default";
+    size_t early_data_context_len = strlen("default");
+
+    end_of_early_data = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+                                       TLS_client_method(), TLS1_3_VERSION, 0,
+                                       &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (
+        !TEST_true(SSL_CTX_set_max_early_data(sctx, 0xffffffff))
+        || !TEST_true(SSL_CTX_set_max_early_data(cctx, 0xffffffff))
+        || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL, NULL)))
+        goto end;
+
+    /* Reset the BIOs we set in create_ssl_objects. We should not need them */
+    SSL_set_bio(serverssl, NULL, NULL);
+    SSL_set_bio(clientssl, NULL, NULL);
+
+    if (!TEST_true(SSL_set_quic_method(clientssl, &quic_api_method))
+        || !TEST_true(SSL_set_quic_method(serverssl, &quic_api_method))
+        || !TEST_true(SSL_set_quic_transport_params(clientssl, cparams, sizeof(cparams)))
+        || !TEST_true(SSL_set_quic_transport_params(serverssl, sparams, sizeof(sparams)))
+        || !TEST_true(SSL_set_app_data(serverssl, clientssl))
+        || !TEST_true(SSL_set_app_data(clientssl, serverssl))
+        || !TEST_true(SSL_set_quic_early_data_context(serverssl, early_data_context, early_data_context_len))
+        )
+        goto end; 
+
+    if(!TEST_true(create_bare_ssl_connection_ex(serverssl, clientssl, SSL_ERROR_NONE, 1, 0,
+                                                &cm_count, &sm_count)))
+        goto end;
+
+    /* Test post-handshake message (NewSessionTicket) */
+    if(!TEST_true(SSL_process_quic_post_handshake(clientssl)))
+        goto end;
+
+    /* Test that we (correctly) fail to send KeyUpdate */
+    /*
+    if (!TEST_true(SSL_key_update(clientssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_int_le(SSL_do_handshake(clientssl), 0))
+        goto end;
+    if (!TEST_true(SSL_key_update(serverssl, SSL_KEY_UPDATE_NOT_REQUESTED))
+        || !TEST_int_le(SSL_do_handshake(serverssl), 0))
+        goto end;
+    */
+
+    /* Check version and encryption level */
+    if(!TEST_true(SSL_version(serverssl) == TLS1_3_VERSION)
+       || !TEST_true(SSL_version(clientssl) == TLS1_3_VERSION)
+       || !(TEST_int_eq(SSL_quic_read_level(clientssl), ssl_encryption_application))
+       || !(TEST_int_eq(SSL_quic_read_level(serverssl), ssl_encryption_application))
+       || !(TEST_int_eq(SSL_quic_write_level(clientssl), ssl_encryption_application))
+       || !(TEST_int_eq(SSL_quic_write_level(serverssl), ssl_encryption_application))
+       )
+       goto end;
+
+    /* Check QUIC transport parameters */
+    SSL_get_peer_quic_transport_params(clientssl, &cpeerparams, &cpeerparams_length);
+    SSL_get_peer_quic_transport_params(serverssl, &speerparams, &speerparams_length);
+   
+    if (!TEST_mem_eq(sparams, sizeof(sparams), cpeerparams, cpeerparams_length)
+        || !TEST_mem_eq(cparams, sizeof(cparams), speerparams, speerparams_length))
+        goto end;
+
+    /* Check early data */
+    sess = SSL_get1_session(clientssl);
+    SSL_shutdown(clientssl);
+    SSL_shutdown(serverssl);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    serverssl = clientssl = NULL;
+    
+    /* 
+     * Use random data rather than zero to prevent the false positive
+     * case that the callback functions are not called during the 
+     * (resumed) handshake.
+     */
+    RAND_bytes((unsigned char *)&csecdata, sizeof(csecdata));
+    RAND_bytes((unsigned char *)&ssecdata, sizeof(ssecdata));
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl, NULL, NULL))
+        || !TEST_true(SSL_set_session(clientssl, sess)))
+        goto end;
+
+    SSL_set_bio(serverssl, NULL, NULL);
+    SSL_set_bio(clientssl, NULL, NULL);
+
+    if (!TEST_true(SSL_set_quic_method(clientssl, &quic_api_method))
+        || !TEST_true(SSL_set_quic_method(serverssl, &quic_api_method))
+        || !TEST_true(SSL_set_quic_transport_params(clientssl, cparams, sizeof(cparams)))
+        || !TEST_true(SSL_set_quic_transport_params(serverssl, sparams, sizeof(sparams)))
+        /* QUIC API method test needs app_data to communicate */
+        || !TEST_true(SSL_set_app_data(serverssl, clientssl))
+        || !TEST_true(SSL_set_app_data(clientssl, serverssl))
+        /* If this is not set, SSL_accept should fail */
+        || !TEST_true(SSL_set_quic_early_data_context(serverssl, early_data_context, early_data_context_len))
+        )
+        goto end;
+
+    /* Use a different API call */
+    SSL_set_quic_early_data_enabled(clientssl, 1);
+    SSL_set_quic_early_data_enabled(serverssl, 1);
+
+    SSL_set_msg_callback(serverssl, assert_no_end_of_early_data);
+    SSL_set_msg_callback(clientssl, assert_no_end_of_early_data);
+    
+    if (!TEST_int_eq(SSL_connect(clientssl), -1)
+            || !TEST_int_eq(SSL_accept(serverssl), -1)
+            || !TEST_int_eq(SSL_get_early_data_status(serverssl), SSL_EARLY_DATA_ACCEPTED)
+            || !TEST_int_eq(SSL_get_error(clientssl, 0), SSL_ERROR_WANT_READ)
+            || !TEST_int_eq(SSL_get_error(serverssl, 0), SSL_ERROR_WANT_READ)
+        )
+        goto end;
+
+    /* Check the encryption levels are what we expect them to be */
+    if (!TEST_true(SSL_quic_read_level(serverssl) == ssl_encryption_handshake)
+        || !TEST_true(SSL_quic_write_level(serverssl) == ssl_encryption_application)
+        || !TEST_true(SSL_quic_read_level(clientssl) == ssl_encryption_initial)
+        || !TEST_true(SSL_quic_write_level(clientssl) == ssl_encryption_early_data))
+    goto end;
+
+    if (!TEST_true(create_ssl_connection_ex(serverssl, clientssl, SSL_ERROR_NONE,
+                                            &cm_count, &sm_count)))
+        goto end;
+
+    /* Check the secrets all match */
+    for (i = 0; i < 3; i++) {
+        if (!TEST_mem_eq(ssecdata.wsecret[i], ssecdata.wsecret_len[i],
+                         csecdata.rsecret[i], csecdata.rsecret_len[i]))
+            goto end;
+    }
+
+    /* Check the transport params */
+    SSL_get_peer_quic_transport_params(clientssl, &cpeerparams, &cpeerparams_length);
+    SSL_get_peer_quic_transport_params(serverssl, &speerparams, &speerparams_length);
+   
+    if (!TEST_mem_eq(sparams, sizeof(sparams), cpeerparams, cpeerparams_length)
+        || !TEST_mem_eq(cparams, sizeof(cparams), speerparams, speerparams_length))
+        goto end;
+
+    /* Check the encryption levels are what we expect them to be */
+    if (!(TEST_int_eq(SSL_quic_read_level(clientssl), ssl_encryption_application))
+        || !(TEST_int_eq(SSL_quic_read_level(serverssl), ssl_encryption_application))
+        || !(TEST_int_eq(SSL_quic_write_level(clientssl), ssl_encryption_application))
+        || !(TEST_int_eq(SSL_quic_write_level(serverssl), ssl_encryption_application))
+        )
+        goto end;
+    /* 
+     * Check alert: There should be no alert except for 0 (close_notify), 
+     * which is raised by SSL_shutdown.
+     */
+    if (!TEST_int_eq(quic_api_test_alert, 0))
+        goto end;
+
+    /* Check there is no EndOfEearlyData in handshake */
+    if (!TEST_int_eq(end_of_early_data, 0))
+        goto end;
+
+    testresult = 1;
+end:    
+    SSL_SESSION_free(sess);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 #endif /* !defined(OSSL_NO_USABLE_TLS1_3) */
 
 static int test_no_renegotiation(int idx)
@@ -13694,6 +13969,7 @@ int setup_tests(void)
 #if !defined(OSSL_NO_USABLE_TLS1_3)
     ADD_ALL_TESTS(test_quic_tls, 6);
     ADD_TEST(test_quic_tls_early_data);
+    ADD_TEST(test_quic_tls_api_method);
 #endif
     ADD_ALL_TESTS(test_no_renegotiation, 2);
 #if defined(DO_SSL_TRACE_TEST)

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -694,3 +694,13 @@ SSL_CTX_enable_force_ntls               694	3_0_3	EXIST::FUNCTION:NTLS
 SSL_CTX_disable_force_ntls              695	3_0_3	EXIST::FUNCTION:NTLS
 SSL_enable_force_ntls                   696	3_0_3	EXIST::FUNCTION:NTLS
 SSL_disable_force_ntls                  697	3_0_3	EXIST::FUNCTION:NTLS
+SSL_set_quic_method                     698	3_5_0	EXIST::FUNCTION:
+SSL_process_quic_post_handshake         699	3_5_0	EXIST::FUNCTION:
+SSL_set_quic_early_data_enabled         700	3_5_0	EXIST::FUNCTION:
+SSL_quic_read_level                     701	3_5_0	EXIST::FUNCTION:
+SSL_quic_write_level                    702	3_5_0	EXIST::FUNCTION:
+SSL_set_quic_early_data_context         703	3_5_0	EXIST::FUNCTION:
+SSL_provide_quic_data                   704	3_5_0	EXIST::FUNCTION:
+SSL_set_quic_use_legacy_codepoint       705	3_5_0	EXIST::FUNCTION:
+SSL_get_peer_quic_transport_params      706	3_5_0	EXIST::FUNCTION:
+SSL_set_quic_transport_params           707	3_5_0	EXIST::FUNCTION:


### PR DESCRIPTION
Some QUIC libraries only supports Tongsuo's BoringSSL-style APIs, so we provide a temporary workaround by wrapping the OpenSSL-style APIs introduced in 8.5.0-pre1.
But we also mention that the BoringSSL-style APIs may be removed in future releases, since they are indeed redundant interfaces and increase maintenance burden.
We suggest that maintainers and developers provide OpenSSL-style PRs to those QUIC libraries that only support BoringSSL-APIs.